### PR TITLE
Add support for styling with CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,34 @@ You can also point it to any other template file:
 svg = SVG.new template: 'path/to/template.svg'
 ```
 
-This is what a basic template looks like:
+See the [templates] folder for an understanding of how templates are 
+structured.
 
-```xml
-<svg %{attributes}>
-%{content}
-</svg>
+
+CSS
+--------------------------------------------------
+
+To add a CSS to your SVG, simply use the `css` command inside your `build` 
+block, like this:
+
+```ruby
+svg = SVG.new
+
+svg.build do 
+  css['.main'] = {
+    stroke: "green", 
+    stroke_width: 2,
+    fill: "yellow"
+  }
+
+  circle cx: 35, cy: 35, r: 20, class: 'main'
+end
 ```
+
+Underscore characters will be converted to dashes (`stroke_width` becomes 
+`stroke-width`).
 
 ---
 
 [examples]: https://github.com/DannyBen/victor/tree/master/examples#examples
+[templates]: https://github.com/DannyBen/victor/tree/master/lib/victor/templates

--- a/examples/01_hello_world.svg
+++ b/examples/01_hello_world.svg
@@ -2,6 +2,14 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
 <rect x="0" y="0" width="100" height="100" style="fill:#ccc"/>
 <rect x="20" y="20" width="60" height="60" style="fill:#f99" transform="rotate(10 40 40)"/>
+
 </svg>

--- a/examples/03_shapes.svg
+++ b/examples/03_shapes.svg
@@ -2,9 +2,17 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg width="202" height="204" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
 <rect x="2" y="2" width="200" height="200" fill="#fcc" style="stroke:yellow; stroke_width:4"/>
 <circle cx="60" cy="50" r="30" style="stroke:yellow; stroke_width:4" fill="red"/>
 <ellipse cx="100" cy="140" rx="80" ry="20" style="stroke:yellow; stroke_width:4" fill="green"/>
 <line x1="100" y1="60" x2="110" y2="100" style="stroke:yellow; stroke_width:4"/>
 <polygon points="150,20 180,80 120,80" fill="blue" style="stroke:yellow; stroke_width:4"/>
+
 </svg>

--- a/examples/04_path.svg
+++ b/examples/04_path.svg
@@ -2,7 +2,15 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
 <rect x="0" y="0" width="200" height="200" fill="#ddd"/>
 <path d="M100,90 q  180 -140 0 70" fill="red"/>
 <path d="M100,90 q -180 -140 0 70" fill="red"/>
+
 </svg>

--- a/examples/05_path_as_array.svg
+++ b/examples/05_path_as_array.svg
@@ -2,7 +2,15 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
 <rect x="0" y="0" width="200" height="200" fill="#ddd"/>
 <path d="M 100 90 q 180 -140 0 70" fill="red"/>
 <path d="M 100 90 q -180 -140 0 70" fill="red"/>
+
 </svg>

--- a/examples/06_text.svg
+++ b/examples/06_text.svg
@@ -2,8 +2,16 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg viewBox="0 0 700 70" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
 <rect x="0" y="0" width="700" height="70" fill="#ddd"/>
 <text x="100" y="50" font-family="arial" font-weight="bold" font-size="40" fill="blue">
 Victor
 </text>
+
 </svg>

--- a/examples/07_nested.svg
+++ b/examples/07_nested.svg
@@ -2,10 +2,18 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg width="420" height="80" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
 <rect x="0" y="0" width="420" height="80" fill="#666"/>
 <g font-size="30" font-family="arial" fill="white">
 <text x="40" y="50">
 Scalable Victor Graphics
 </text>
 </g>
+
 </svg>

--- a/examples/08_css.rb
+++ b/examples/08_css.rb
@@ -1,0 +1,19 @@
+require 'victor'
+
+svg = SVG.new width: 400, height: 400, viewBox: "0 0 100 100", 
+  style: { background: '#eee' }
+
+svg.build do 
+  css['.main'] = {
+    stroke: "green", 
+    stroke_width: 2,
+    fill: "yellow",
+    opacity: 0.7
+  }
+
+  rect x: 5, y: 5, width: 60, height: 60, class: 'main'
+  circle cx: 35, cy: 35, r: 20, class: 'main'
+end
+
+svg.save '08_css.svg'
+

--- a/examples/08_css.svg
+++ b/examples/08_css.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg width="400" height="400" viewBox="0 0 100 100" style="background:#eee" xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+  .main {
+    stroke: green;
+    stroke-width: 2;
+    fill: yellow;
+    opacity: 0.7;
+}
+]]>
+</style>
+
+<rect x="5" y="5" width="60" height="60" class="main"/>
+<circle cx="35" cy="35" r="20" class="main"/>
+
+</svg>

--- a/examples/README.md
+++ b/examples/README.md
@@ -159,6 +159,32 @@ svg.save '07_nested'
 [![07_nested](https://cdn.rawgit.com/DannyBen/victor/master/examples/07_nested.svg)](https://github.com/DannyBen/victor/blob/master/examples/07_nested.rb)
 
 
+## 08_css
+
+```ruby
+require 'victor'
+
+svg = SVG.new width: 400, height: 400, viewBox: "0 0 100 100", 
+  style: { background: '#eee' }
+
+svg.build do 
+  css['.main'] = {
+    stroke: "green", 
+    stroke_width: 2,
+    fill: "yellow",
+    opacity: 0.7
+  }
+
+  rect x: 5, y: 5, width: 60, height: 60, class: 'main'
+  circle cx: 35, cy: 35, r: 20, class: 'main'
+end
+
+svg.save '08_css.svg'
+```
+
+[![08_css](https://cdn.rawgit.com/DannyBen/victor/master/examples/08_css.svg)](https://github.com/DannyBen/victor/blob/master/examples/08_css.rb)
+
+
 
 ---
 

--- a/lib/victor.rb
+++ b/lib/victor.rb
@@ -1,5 +1,6 @@
 require 'victor/version'
 require 'victor/svg'
 require 'victor/attributes'
+require 'victor/css'
 
 include Victor

--- a/lib/victor/css.rb
+++ b/lib/victor/css.rb
@@ -1,0 +1,27 @@
+
+
+module Victor
+
+  class CSS
+    attr_reader :attributes
+
+    def initialize(attributes={})
+      @attributes = attributes
+    end
+
+    def to_s
+      result = []
+      attributes.each do |selector, styles|
+        result.push "  #{selector} {"
+        styles.each do |key, value|
+          key = key.to_s.tr '_', '-'
+          result.push "    #{key}: #{value};"
+        end
+        result.push "  }"
+      end
+
+      result.join "\n"
+    end
+  end
+
+end

--- a/lib/victor/svg.rb
+++ b/lib/victor/svg.rb
@@ -3,7 +3,7 @@
 module Victor
 
   class SVG
-    attr_accessor :template
+    attr_accessor :template, :css
     attr_reader :content, :svg_attributes
 
     def initialize(attributes={})
@@ -12,6 +12,7 @@ module Victor
       svg_attributes[:width] ||= "100%"
       svg_attributes[:height] ||= "100%"
       @content = []
+      @css = {}
     end
 
     def method_missing(method_sym, *arguments, &block)
@@ -40,7 +41,11 @@ module Victor
     end
 
     def render
-      svg_template % { attributes: svg_attributes, content: content.join("\n") }
+      svg_template % { 
+        css: CSS.new(css),
+        attributes: svg_attributes, 
+        content: content.join("\n") 
+      }
     end
 
     def save(filename)

--- a/lib/victor/templates/default.svg
+++ b/lib/victor/templates/default.svg
@@ -2,5 +2,13 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
 <svg %{attributes} xmlns="http://www.w3.org/2000/svg">
+
+<style type="text/css">
+<![CDATA[
+%{css}
+]]>
+</style>
+
 %{content}
+
 </svg>

--- a/lib/victor/templates/html.svg
+++ b/lib/victor/templates/html.svg
@@ -1,3 +1,10 @@
 <svg %{attributes}>
+
+<style type="text/css" scoped>
+<![CDATA[
+%{css}
+]]>
+</style>
+
 %{content}
 </svg>

--- a/spec/victor/css_spec.rb
+++ b/spec/victor/css_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe CSS do
+
+  describe '#to_s' do
+    it "converts to a valid css" do
+      css = {}
+      css['.main'] = { 
+        color: 'black', 
+        background: 'white' 
+      } 
+
+      subject = CSS.new css
+      expect(subject.to_s).to eq "  .main {\n    color: black;\n    background: white;\n  }"
+    end
+  end
+
+end

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -90,7 +90,7 @@ describe SVG do
       it "loads a built in template" do
         svg.template = :html
         svg.circle of: 'trust'
-        expect(svg.render).to eq "<svg width=\"100%\" height=\"100%\">\n<circle of=\"trust\"/>\n</svg>"
+        expect(svg.render).to eq "<svg width=\"100%\" height=\"100%\">\n\n<style type=\"text/css\" scoped>\n<![CDATA[\n\n]]>\n</style>\n\n<circle of=\"trust\"/>\n</svg>"
       end
     end
 
@@ -111,6 +111,23 @@ describe SVG do
       expect(svg.render).to match /DOCTYPE svg PUBLIC/
       expect(svg.render).to match /svg width="100%" height="100%"/
       expect(svg.render).to match /<circle radius="10"\/>/
+    end
+
+    context "with css elements" do
+      before do
+        @css = {}
+        @css['.main'] = { 
+          stroke: "green", 
+          stroke_width: 2,
+        } 
+      end
+
+      it "includes a css block" do
+        svg.css = @css
+        expect(svg.render).to match /.main \{/
+        expect(svg.render).to match /stroke: green;/
+        expect(svg.render).to match /stroke-width: 2;/
+      end
     end
   end
 


### PR DESCRIPTION
Using the `css` command in a `build` block (or with `svg.css`) now allows to add a `<style>` block to the SVG. This is a 'hash to css' direct conversion.

```ruby
css['.main'] = {
  stroke: "green", 
  stroke_width: 2,
  fill: "yellow",
  opacity: 0.7
}
```

Closes #9 