### PR TITLE
Add defs and pattern example

### DIFF
--- a/examples/01_hello_world.rb
+++ b/examples/01_hello_world.rb
@@ -11,5 +11,8 @@ end
 # If you want the XML itself:
 result = svg.render
 
+# If you want the XML without the surrounding template:
+result = svg.to_s
+
 # If you want to save:
 svg.save '01_hello_world'

--- a/examples/01_hello_world.svg
+++ b/examples/01_hello_world.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/03_shapes.svg
+++ b/examples/03_shapes.svg
@@ -9,10 +9,10 @@
 ]]>
 </style>
 
-<rect x="2" y="2" width="200" height="200" fill="#fcc" style="stroke:yellow; stroke_width:4"/>
-<circle cx="60" cy="50" r="30" style="stroke:yellow; stroke_width:4" fill="red"/>
-<ellipse cx="100" cy="140" rx="80" ry="20" style="stroke:yellow; stroke_width:4" fill="green"/>
-<line x1="100" y1="60" x2="110" y2="100" style="stroke:yellow; stroke_width:4"/>
-<polygon points="150,20 180,80 120,80" fill="blue" style="stroke:yellow; stroke_width:4"/>
+<rect x="2" y="2" width="200" height="200" fill="#fcc" style="stroke:yellow; stroke-width:4"/>
+<circle cx="60" cy="50" r="30" style="stroke:yellow; stroke-width:4" fill="red"/>
+<ellipse cx="100" cy="140" rx="80" ry="20" style="stroke:yellow; stroke-width:4" fill="green"/>
+<line x1="100" y1="60" x2="110" y2="100" style="stroke:yellow; stroke-width:4"/>
+<polygon points="150,20 180,80 120,80" fill="blue" style="stroke:yellow; stroke-width:4"/>
 
 </svg>

--- a/examples/11_def_pattern.rb
+++ b/examples/11_def_pattern.rb
@@ -1,31 +1,22 @@
 require 'victor'
 
-svg = SVG.new viewBox:"0 0 400 400"
+svg = SVG.new width: 300, height: 300, viewBox:"0 0 400 300"
 
 svg.build do
   
   # Define a reusable pattern using SVG defs>
   defs do
-    linearGradient id: "Gradient1" do
-      stop offset: "5%", stop_color: "white"
-      stop offset: "95%", stop_color: "blue"
-    end
-
-    linearGradient id: "Gradient2", x1: "0", x2: "0", y1: "0", y2: "1" do
-      stop offset: "5%", stop_color: "red"
-      stop offset: "95%", stop_color: "orange"
-    end
-
-    pattern id: "Pattern", x: "0", y: "0", width: "50", height: "50", patternUnits: "userSpaceOnUse" do
-      rect x: "0", y: "0", width: "50", height: "50", fill: "skyblue"
-      rect x: "0", y: "0", width: "25", height: "25", fill: "url(#Gradient2)"
-      circle cx: "25", cy: "25", r: "20", fill: "url(#Gradient1)", fill_opacity: "0.5"
+    pattern id: "Pattern", x: "0", y: "0", width: "75", height: "50", patternUnits: "userSpaceOnUse" do
+      rect x: "0" , y: "0", width: "25", height: "50", fill: "black"
+      rect x: "25", y: "0", width: "25", height: "50", fill: "red"
+      rect x: "50", y: "0", width: "25", height: "50", fill: "yellow"
     end
   end
 
   # Use the pattern as a background fill for two shapes
   rect fill: "url(#Pattern)", stroke: "black", x: "0", y: "0", width: "300", height: "150"
-  circle fill: "url(#Pattern)", stroke: "black", cx: "200", cy: "200", r: "100"
+  circle fill: "url(#Pattern)", stroke: "black", cx: "150", cy: "150", r: "100",
+    transform: 'rotate(90 150 150)'
 end
 
 # Save it

--- a/examples/11_def_pattern.rb
+++ b/examples/11_def_pattern.rb
@@ -1,0 +1,32 @@
+require 'victor'
+
+svg = SVG.new viewBox:"0 0 400 400"
+
+svg.build do
+  
+  # Define a reusable pattern using SVG defs>
+  defs do
+    linearGradient id: "Gradient1" do
+      stop offset: "5%", stop_color: "white"
+      stop offset: "95%", stop_color: "blue"
+    end
+
+    linearGradient id: "Gradient2", x1: "0", x2: "0", y1: "0", y2: "1" do
+      stop offset: "5%", stop_color: "red"
+      stop offset: "95%", stop_color: "orange"
+    end
+
+    pattern id: "Pattern", x: "0", y: "0", width: "50", height: "50", patternUnits: "userSpaceOnUse" do
+      rect x: "0", y: "0", width: "50", height: "50", fill: "skyblue"
+      rect x: "0", y: "0", width: "25", height: "25", fill: "url(#Gradient2)"
+      circle cx: "25", cy: "25", r: "20", fill: "url(#Gradient1)", fill_opacity: "0.5"
+    end
+  end
+
+  # Use the pattern as a background fill for two shapes
+  rect fill: "url(#Pattern)", stroke: "black", x: "0", y: "0", width: "300", height: "150"
+  circle fill: "url(#Pattern)", stroke: "black", cx: "200", cy: "200", r: "100"
+end
+
+# Save it
+svg.save '11_def_pattern'

--- a/examples/11_def_pattern.svg
+++ b/examples/11_def_pattern.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg viewBox="0 0 400 400" width="100%" height="100%" 
+<svg width="300" height="300" viewBox="0 0 400 300" 
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -12,21 +12,13 @@
 </style>
 
 <defs>
-<linearGradient id="Gradient1">
-<stop offset="5%" stop-color="white"/>
-<stop offset="95%" stop-color="blue"/>
-</linearGradient>
-<linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
-<stop offset="5%" stop-color="red"/>
-<stop offset="95%" stop-color="orange"/>
-</linearGradient>
-<pattern id="Pattern" x="0" y="0" width="50" height="50" patternUnits="userSpaceOnUse">
-<rect x="0" y="0" width="50" height="50" fill="skyblue"/>
-<rect x="0" y="0" width="25" height="25" fill="url(#Gradient2)"/>
-<circle cx="25" cy="25" r="20" fill="url(#Gradient1)" fill-opacity="0.5"/>
+<pattern id="Pattern" x="0" y="0" width="75" height="50" patternUnits="userSpaceOnUse">
+<rect x="0" y="0" width="25" height="50" fill="black"/>
+<rect x="25" y="0" width="25" height="50" fill="red"/>
+<rect x="50" y="0" width="25" height="50" fill="yellow"/>
 </pattern>
 </defs>
 <rect fill="url(#Pattern)" stroke="black" x="0" y="0" width="300" height="150"/>
-<circle fill="url(#Pattern)" stroke="black" cx="200" cy="200" r="100"/>
+<circle fill="url(#Pattern)" stroke="black" cx="150" cy="150" r="100" transform="rotate(90 150 150)"/>
 
 </svg>

--- a/examples/11_def_pattern.svg
+++ b/examples/11_def_pattern.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg viewBox="0 0 400 400" width="100%" height="100%" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
+<defs>
+<linearGradient id="Gradient1">
+<stop offset="5%" stop-color="white"/>
+<stop offset="95%" stop-color="blue"/>
+</linearGradient>
+<linearGradient id="Gradient2" x1="0" x2="0" y1="0" y2="1">
+<stop offset="5%" stop-color="red"/>
+<stop offset="95%" stop-color="orange"/>
+</linearGradient>
+<pattern id="Pattern" x="0" y="0" width="50" height="50" patternUnits="userSpaceOnUse">
+<rect x="0" y="0" width="50" height="50" fill="skyblue"/>
+<rect x="0" y="0" width="25" height="25" fill="url(#Gradient2)"/>
+<circle cx="25" cy="25" r="20" fill="url(#Gradient1)" fill-opacity="0.5"/>
+</pattern>
+</defs>
+<rect fill="url(#Pattern)" stroke="black" x="0" y="0" width="300" height="150"/>
+<circle fill="url(#Pattern)" stroke="black" cx="200" cy="200" r="100"/>
+
+</svg>

--- a/examples/README.md
+++ b/examples/README.md
@@ -250,32 +250,23 @@ svg.save '10_animation'
 ```ruby
 require 'victor'
 
-svg = SVG.new viewBox:"0 0 400 400"
+svg = SVG.new width: 300, height: 300, viewBox:"0 0 400 300"
 
 svg.build do
   
   # Define a reusable pattern using SVG defs>
   defs do
-    linearGradient id: "Gradient1" do
-      stop offset: "5%", stop_color: "white"
-      stop offset: "95%", stop_color: "blue"
-    end
-
-    linearGradient id: "Gradient2", x1: "0", x2: "0", y1: "0", y2: "1" do
-      stop offset: "5%", stop_color: "red"
-      stop offset: "95%", stop_color: "orange"
-    end
-
-    pattern id: "Pattern", x: "0", y: "0", width: "50", height: "50", patternUnits: "userSpaceOnUse" do
-      rect x: "0", y: "0", width: "50", height: "50", fill: "skyblue"
-      rect x: "0", y: "0", width: "25", height: "25", fill: "url(#Gradient2)"
-      circle cx: "25", cy: "25", r: "20", fill: "url(#Gradient1)", fill_opacity: "0.5"
+    pattern id: "Pattern", x: "0", y: "0", width: "75", height: "50", patternUnits: "userSpaceOnUse" do
+      rect x: "0" , y: "0", width: "25", height: "50", fill: "black"
+      rect x: "25", y: "0", width: "25", height: "50", fill: "red"
+      rect x: "50", y: "0", width: "25", height: "50", fill: "yellow"
     end
   end
 
   # Use the pattern as a background fill for two shapes
   rect fill: "url(#Pattern)", stroke: "black", x: "0", y: "0", width: "300", height: "150"
-  circle fill: "url(#Pattern)", stroke: "black", cx: "200", cy: "200", r: "100"
+  circle fill: "url(#Pattern)", stroke: "black", cx: "150", cy: "150", r: "100",
+    transform: 'rotate(90 150 150)'
 end
 
 # Save it

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,9 @@ end
 # If you want the XML itself:
 result = svg.render
 
+# If you want the XML without the surrounding template:
+result = svg.to_s
+
 # If you want to save:
 svg.save '01_hello_world'
 ```
@@ -240,6 +243,46 @@ svg.save '10_animation'
 ```
 
 [![10_animation](https://cdn.rawgit.com/DannyBen/victor/master/examples/10_animation.svg)](https://github.com/DannyBen/victor/blob/master/examples/10_animation.rb)
+
+
+## 11 def pattern
+
+```ruby
+require 'victor'
+
+svg = SVG.new viewBox:"0 0 400 400"
+
+svg.build do
+  
+  # Define a reusable pattern using SVG defs>
+  defs do
+    linearGradient id: "Gradient1" do
+      stop offset: "5%", stop_color: "white"
+      stop offset: "95%", stop_color: "blue"
+    end
+
+    linearGradient id: "Gradient2", x1: "0", x2: "0", y1: "0", y2: "1" do
+      stop offset: "5%", stop_color: "red"
+      stop offset: "95%", stop_color: "orange"
+    end
+
+    pattern id: "Pattern", x: "0", y: "0", width: "50", height: "50", patternUnits: "userSpaceOnUse" do
+      rect x: "0", y: "0", width: "50", height: "50", fill: "skyblue"
+      rect x: "0", y: "0", width: "25", height: "25", fill: "url(#Gradient2)"
+      circle cx: "25", cy: "25", r: "20", fill: "url(#Gradient1)", fill_opacity: "0.5"
+    end
+  end
+
+  # Use the pattern as a background fill for two shapes
+  rect fill: "url(#Pattern)", stroke: "black", x: "0", y: "0", width: "300", height: "150"
+  circle fill: "url(#Pattern)", stroke: "black", cx: "200", cy: "200", r: "100"
+end
+
+# Save it
+svg.save '11_def_pattern'
+```
+
+[![11_def_pattern](https://cdn.rawgit.com/DannyBen/victor/master/examples/11_def_pattern.svg)](https://github.com/DannyBen/victor/blob/master/examples/11_def_pattern.rb)
 
 
 

--- a/lib/victor/svg.rb
+++ b/lib/victor/svg.rb
@@ -1,5 +1,3 @@
-
-
 module Victor
 
   class SVG
@@ -44,8 +42,12 @@ module Victor
       svg_template % { 
         css: CSS.new(css),
         attributes: svg_attributes, 
-        content: content.join("\n") 
+        content: content.join("\n")
       }
+    end
+
+    def to_s
+      content.join "\n"
     end
 
     def save(filename)

--- a/lib/victor/templates/default.svg
+++ b/lib/victor/templates/default.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg %{attributes} xmlns="http://www.w3.org/2000/svg">
+<svg %{attributes} 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -131,6 +131,13 @@ describe SVG do
     end
   end
 
+  describe '#to_s' do
+    it "returns svg xml as string" do
+      svg.circle radius: 10
+      expect(svg.to_s).to eq '<circle radius="10"/>'
+    end    
+  end
+
   describe '#save' do
     let(:filename) { 'test.svg' }
 


### PR DESCRIPTION
This PR:

1. Adds a `#to_s` method, that returns the SVG as a string. This is similar to `#render`, only it returns teh SVG without any surrounding template.
2. Adds `xmlns:xlink` namespace, to support the common use of `<defs>` and `<use>`
3. Adds an example that demonstrates the use of `defs` and `pattern`