### PR TITLE
Add support for single line CSS

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -53,12 +53,11 @@ action :readme do
   Dir['examples/*.rb'].each do |file|
     say_status :process, file
 
-
     basename = File.basename file, '.rb'
     title = basename.tr '_', ' '
     code  = File.read(file).strip
     if File.exist? "examples/#{basename}.svg"
-      image = "[![#{basename}](https://cdn.rawgit.com/DannyBen/victor/master/examples/#{basename}.svg)](https://github.com/DannyBen/victor/blob/master/#{file})"
+      image = "[![#{basename}](https://cdn.rawgit.com/DannyBen/victor/master/examples/#{basename}.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/#{basename}.svg)"
     else
       image = false
     end
@@ -67,6 +66,11 @@ action :readme do
     result.push "```ruby"
     result.push code
     result.push "```\n"
+    if image
+      result.push "[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/#{file}) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/#{basename}.svg)\n"
+    else
+      result.push "[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/#{file})\n"
+    end
     result.push image if image
     result.push "\n"
   end

--- a/examples/12_custom_fonts.rb
+++ b/examples/12_custom_fonts.rb
@@ -1,0 +1,25 @@
+require 'victor'
+
+svg = SVG.new width: 300, height: 130, viewBox:"0 0 300 130"
+
+svg.build do
+  
+  # Whenever the value of a CSS entry is an array, each item in the
+  # array will simply be placed after the key,separated by a space
+  # so this will create two '@import url(...)' statements.
+  css['@import'] = [
+    "url('https://fonts.googleapis.com/css?family=Audiowide')",
+    "url('https://fonts.googleapis.com/css?family=Pacifico')"
+  ]
+
+  rect x: 0, y: 0, width: '100%', height: '100%', fill: '#779'
+
+  svg.text "Custom Fonts?", text_anchor: :middle, x: '50%', y: 50, 
+    font_family: 'Audiowide', font_size: 30, fill: :white
+
+  svg.text "No problem!", text_anchor: :middle, x: '50%', y: 100, 
+    font_family: 'Pacifico', font_size: 30
+end
+
+svg.save '12_custom_fonts'
+

--- a/examples/12_custom_fonts.rb
+++ b/examples/12_custom_fonts.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 300, height: 130, viewBox:"0 0 300 130"
+svg = SVG.new width: 300, height: 180, viewBox:"0 0 300 180"
 
 svg.build do
   
@@ -19,7 +19,17 @@ svg.build do
 
   svg.text "No problem!", text_anchor: :middle, x: '50%', y: 100, 
     font_family: 'Pacifico', font_size: 30
+
+  svg.text "this example does not work", 
+    text_anchor: :middle, x: '50%', y: 140, 
+    font_family: 'arial', font_size: 16
+
+  svg.text "when embedded in HTML", 
+    text_anchor: :middle, x: '50%', y: 160, 
+    font_family: 'arial', font_size: 16
 end
 
 svg.save '12_custom_fonts'
+
+
 

--- a/examples/12_custom_fonts.svg
+++ b/examples/12_custom_fonts.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="300" height="130" viewBox="0 0 300 130" 
+<svg width="300" height="180" viewBox="0 0 300 180" 
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -18,6 +18,12 @@ Custom Fonts?
 </text>
 <text text-anchor="middle" x="50%" y="100" font-family="Pacifico" font-size="30">
 No problem!
+</text>
+<text text-anchor="middle" x="50%" y="140" font-family="arial" font-size="16">
+this example does not work
+</text>
+<text text-anchor="middle" x="50%" y="160" font-family="arial" font-size="16">
+when embedded in HTML
 </text>
 
 </svg>

--- a/examples/12_custom_fonts.svg
+++ b/examples/12_custom_fonts.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg width="300" height="130" viewBox="0 0 300 130" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+<style type="text/css">
+<![CDATA[
+  @import url('https://fonts.googleapis.com/css?family=Audiowide');
+  @import url('https://fonts.googleapis.com/css?family=Pacifico');
+]]>
+</style>
+
+<rect x="0" y="0" width="100%" height="100%" fill="#779"/>
+<text text-anchor="middle" x="50%" y="50" font-family="Audiowide" font-size="30" fill="white">
+Custom Fonts?
+</text>
+<text text-anchor="middle" x="50%" y="100" font-family="Pacifico" font-size="30">
+No problem!
+</text>
+
+</svg>

--- a/examples/README.md
+++ b/examples/README.md
@@ -276,6 +276,38 @@ svg.save '11_def_pattern'
 [![11_def_pattern](https://cdn.rawgit.com/DannyBen/victor/master/examples/11_def_pattern.svg)](https://github.com/DannyBen/victor/blob/master/examples/11_def_pattern.rb)
 
 
+## 12 custom fonts
+
+```ruby
+require 'victor'
+
+svg = SVG.new width: 300, height: 130, viewBox:"0 0 300 130"
+
+svg.build do
+  
+  # Whenever the value of a CSS entry is an array, each item in the
+  # array will simply be placed after the key,separated by a space
+  # so this will create two '@import url(...)' statements.
+  css['@import'] = [
+    "url('https://fonts.googleapis.com/css?family=Audiowide')",
+    "url('https://fonts.googleapis.com/css?family=Pacifico')"
+  ]
+
+  rect x: 0, y: 0, width: '100%', height: '100%', fill: '#779'
+
+  svg.text "Custom Fonts?", text_anchor: :middle, x: '50%', y: 50, 
+    font_family: 'Audiowide', font_size: 30, fill: :white
+
+  svg.text "No problem!", text_anchor: :middle, x: '50%', y: 100, 
+    font_family: 'Pacifico', font_size: 30
+end
+
+svg.save '12_custom_fonts'
+```
+
+[![12_custom_fonts](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)](https://github.com/DannyBen/victor/blob/master/examples/12_custom_fonts.rb)
+
+
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,9 @@ result = svg.to_s
 svg.save '01_hello_world'
 ```
 
-[![01_hello_world](https://cdn.rawgit.com/DannyBen/victor/master/examples/01_hello_world.svg)](https://github.com/DannyBen/victor/blob/master/examples/01_hello_world.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/01_hello_world.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/01_hello_world.svg)
+
+[![01_hello_world](https://cdn.rawgit.com/DannyBen/victor/master/examples/01_hello_world.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/01_hello_world.svg)
 
 
 ## 02 element
@@ -42,6 +44,8 @@ p svg.content
 # => ["<rect x=\"2\" y=\"2\" width=\"200\" height=\"200\" fill=\"#ddd\"/>", 
 #     "<rect x=\"2\" y=\"2\" width=\"200\" height=\"200\" fill=\"#ddd\"/>"]
 ```
+
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/02_element.rb)
 
 
 
@@ -68,7 +72,9 @@ end
 svg.save '03_shapes'
 ```
 
-[![03_shapes](https://cdn.rawgit.com/DannyBen/victor/master/examples/03_shapes.svg)](https://github.com/DannyBen/victor/blob/master/examples/03_shapes.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/03_shapes.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/03_shapes.svg)
+
+[![03_shapes](https://cdn.rawgit.com/DannyBen/victor/master/examples/03_shapes.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/03_shapes.svg)
 
 
 ## 04 path
@@ -88,7 +94,9 @@ end
 svg.save '04_path'
 ```
 
-[![04_path](https://cdn.rawgit.com/DannyBen/victor/master/examples/04_path.svg)](https://github.com/DannyBen/victor/blob/master/examples/04_path.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/04_path.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/04_path.svg)
+
+[![04_path](https://cdn.rawgit.com/DannyBen/victor/master/examples/04_path.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/04_path.svg)
 
 
 ## 05 path as array
@@ -108,7 +116,9 @@ end
 svg.save '05_path_as_array'
 ```
 
-[![05_path_as_array](https://cdn.rawgit.com/DannyBen/victor/master/examples/05_path_as_array.svg)](https://github.com/DannyBen/victor/blob/master/examples/05_path_as_array.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/05_path_as_array.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/05_path_as_array.svg)
+
+[![05_path_as_array](https://cdn.rawgit.com/DannyBen/victor/master/examples/05_path_as_array.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/05_path_as_array.svg)
 
 
 ## 06 text
@@ -124,7 +134,9 @@ svg.text "Victor", x: 100, y: 50, font_family: 'arial', font_weight: 'bold', fon
 svg.save '06_text'
 ```
 
-[![06_text](https://cdn.rawgit.com/DannyBen/victor/master/examples/06_text.svg)](https://github.com/DannyBen/victor/blob/master/examples/06_text.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/06_text.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/06_text.svg)
+
+[![06_text](https://cdn.rawgit.com/DannyBen/victor/master/examples/06_text.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/06_text.svg)
 
 
 ## 07 nested
@@ -145,7 +157,9 @@ end
 svg.save '07_nested'
 ```
 
-[![07_nested](https://cdn.rawgit.com/DannyBen/victor/master/examples/07_nested.svg)](https://github.com/DannyBen/victor/blob/master/examples/07_nested.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/07_nested.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/07_nested.svg)
+
+[![07_nested](https://cdn.rawgit.com/DannyBen/victor/master/examples/07_nested.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/07_nested.svg)
 
 
 ## 08 css
@@ -171,7 +185,9 @@ end
 svg.save '08_css.svg'
 ```
 
-[![08_css](https://cdn.rawgit.com/DannyBen/victor/master/examples/08_css.svg)](https://github.com/DannyBen/victor/blob/master/examples/08_css.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/08_css.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/08_css.svg)
+
+[![08_css](https://cdn.rawgit.com/DannyBen/victor/master/examples/08_css.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/08_css.svg)
 
 
 ## 09 pacman
@@ -197,7 +213,9 @@ end
 svg.save '09_pacman'
 ```
 
-[![09_pacman](https://cdn.rawgit.com/DannyBen/victor/master/examples/09_pacman.svg)](https://github.com/DannyBen/victor/blob/master/examples/09_pacman.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/09_pacman.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/09_pacman.svg)
+
+[![09_pacman](https://cdn.rawgit.com/DannyBen/victor/master/examples/09_pacman.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/09_pacman.svg)
 
 
 ## 10 animation
@@ -242,7 +260,9 @@ end
 svg.save '10_animation'
 ```
 
-[![10_animation](https://cdn.rawgit.com/DannyBen/victor/master/examples/10_animation.svg)](https://github.com/DannyBen/victor/blob/master/examples/10_animation.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/10_animation.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/10_animation.svg)
+
+[![10_animation](https://cdn.rawgit.com/DannyBen/victor/master/examples/10_animation.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/10_animation.svg)
 
 
 ## 11 def pattern
@@ -273,7 +293,9 @@ end
 svg.save '11_def_pattern'
 ```
 
-[![11_def_pattern](https://cdn.rawgit.com/DannyBen/victor/master/examples/11_def_pattern.svg)](https://github.com/DannyBen/victor/blob/master/examples/11_def_pattern.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/11_def_pattern.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/11_def_pattern.svg)
+
+[![11_def_pattern](https://cdn.rawgit.com/DannyBen/victor/master/examples/11_def_pattern.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/11_def_pattern.svg)
 
 
 ## 12 custom fonts
@@ -281,7 +303,7 @@ svg.save '11_def_pattern'
 ```ruby
 require 'victor'
 
-svg = SVG.new width: 300, height: 130, viewBox:"0 0 300 130"
+svg = SVG.new width: 300, height: 180, viewBox:"0 0 300 180"
 
 svg.build do
   
@@ -300,12 +322,22 @@ svg.build do
 
   svg.text "No problem!", text_anchor: :middle, x: '50%', y: 100, 
     font_family: 'Pacifico', font_size: 30
+
+  svg.text "this example does not work", 
+    text_anchor: :middle, x: '50%', y: 140, 
+    font_family: 'arial', font_size: 16
+
+  svg.text "when embedded in HTML", 
+    text_anchor: :middle, x: '50%', y: 160, 
+    font_family: 'arial', font_size: 16
 end
 
 svg.save '12_custom_fonts'
 ```
 
-[![12_custom_fonts](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)](https://github.com/DannyBen/victor/blob/master/examples/12_custom_fonts.rb)
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/12_custom_fonts.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)
+
+[![12_custom_fonts](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)
 
 
 

--- a/lib/victor/css.rb
+++ b/lib/victor/css.rb
@@ -23,6 +23,10 @@ module Victor
           result.push " " * indent + "#{key} {"
           result.push convert_hash(value, indent+2)
           result.push " " * indent + "}"
+        elsif value.is_a? Array
+          value.each do |row|
+            result.push " " * indent + "#{key} #{row};"
+          end
         else
           result.push " " * indent + "#{key}: #{value};"
         end

--- a/spec/fixtures/css3.css
+++ b/spec/fixtures/css3.css
@@ -1,0 +1,2 @@
+  @import some url;
+  @import another url;

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,11 @@ require 'rubygems'
 require 'bundler'
 Bundler.require :default, :development
 
-def fixture(file)
-  File.read "spec/fixtures/#{file}"
+def fixture(filename, data=nil)
+  if data
+    File.write "spec/fixtures/#{filename}", data
+    raise "Warning: Fixture data was written.\nThis is perfectly fine if it was intended,\nbut tests cannot proceed with it as a precaution."
+  else
+    File.read "spec/fixtures/#{filename}"
+  end
 end

--- a/spec/victor/css_spec.rb
+++ b/spec/victor/css_spec.rb
@@ -28,6 +28,17 @@ describe CSS do
       subject = CSS.new css
       expect(subject.to_s).to eq fixture('css2.css')
     end
+
+    it "converts array values to single lines" do
+      css = {}
+      css['@import'] = [
+        "some url",
+        "another url"
+      ]
+
+      subject = CSS.new css
+      expect(subject.to_s).to eq fixture('css3.css')
+    end
   end
 
 end


### PR DESCRIPTION
This PR adds the ability to add single-line CSS statements, like `@import` in order to help cases like in issue #16.

See the custom fonts examples folder for a demonstration of custom fonts.

Note that custom fonts do not seem to work when the SVG is embedded in HTML - this is an SVG issue, not a Victor issue.
