### PR TITLE
Remove global include

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Examples
 ```ruby
 require 'victor'
 
-svg = SVG.new width: 140, height: 100, style: { background: '#ddd' }
+svg = Victor::SVG.new width: 140, height: 100, style: { background: '#ddd' }
 
 svg.build do 
   rect x: 10, y: 10, width: 120, height: 80, rx: 10, fill: '#666'
@@ -65,17 +65,17 @@ Initialize your SVG image:
 
 ```ruby
 require 'victor'
-svg = SVG.new
+svg = Victor::SVG.new
 ```
 
 Any option you provide to `SVG.new` will be added as an attribute to the
 main `<svg>` element. By default, `height` and `width` are set to 100%.
 
 ```ruby
-svg = SVG.new width: '100%', height: '100%'
-# same as just SVG.new
+svg = Victor::SVG.new width: '100%', height: '100%'
+# same as just Victor::SVG.new
 
-svg = SVG.new width: '100%', height: '100%', viewBox: "0 0 200 100"
+svg = Victor::SVG.new width: '100%', height: '100%', viewBox: "0 0 200 100"
 ```
 
 Victor uses a single method (`element`) to generate all SVG elements:
@@ -179,14 +179,14 @@ a standalone SVG image). If you wish to use the output as an SVG element
 inside HTML, you can change the SVG template:
 
 ```ruby
-svg = SVG.new template: :html 
+svg = Victor::SVG.new template: :html 
 # accepts :html, :default or a filename
 ```
 
 You can also point it to any other template file:
 
 ```ruby
-svg = SVG.new template: 'path/to/template.svg'
+svg = Victor::SVG.new template: 'path/to/template.svg'
 ```
 
 See the [templates] folder for an understanding of how templates are 
@@ -200,7 +200,7 @@ To add a CSS to your SVG, simply use the `css` command inside your `build`
 block, like this:
 
 ```ruby
-svg = SVG.new
+svg = Victor::SVG.new
 
 svg.build do 
   css['.main'] = {

--- a/Runfile
+++ b/Runfile
@@ -39,6 +39,7 @@ action :build do
   Dir.chdir 'examples' do
     Dir['*.rb'].each do |filename|
       run "ruby #{filename}"
+      abort "Aborting" unless $?.success?
     end
   end
   say_status :done, :build

--- a/examples/01_hello_world.rb
+++ b/examples/01_hello_world.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new
+svg = Victor::SVG.new
 
 svg.build do 
   rect x: 0, y: 0, width: 100, height: 100, style: { fill: '#ccc' }

--- a/examples/02_element.rb
+++ b/examples/02_element.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new
+svg = Victor::SVG.new
 
 # These two are the same
 svg.element :rect, x: 2, y: 2, width: 200, height: 200, fill: '#ddd'

--- a/examples/03_shapes.rb
+++ b/examples/03_shapes.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 202, height: 204
+svg = Victor::SVG.new width: 202, height: 204
 
 style = {
   stroke: 'yellow',

--- a/examples/03_shapes.svg
+++ b/examples/03_shapes.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="202" height="204" xmlns="http://www.w3.org/2000/svg">
+<svg width="202" height="204" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/04_path.rb
+++ b/examples/04_path.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 200, height: 200 
+svg = Victor::SVG.new width: 200, height: 200 
 
 svg.build do 
   rect x: 0, y: 0, width: 200, height: 200, fill: '#ddd'

--- a/examples/04_path.svg
+++ b/examples/04_path.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+<svg width="200" height="200" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/05_path_as_array.rb
+++ b/examples/05_path_as_array.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 200, height: 200 
+svg = Victor::SVG.new width: 200, height: 200 
 
 svg.build do 
   rect x: 0, y: 0, width: 200, height: 200, fill: '#ddd'

--- a/examples/05_path_as_array.svg
+++ b/examples/05_path_as_array.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+<svg width="200" height="200" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/06_text.rb
+++ b/examples/06_text.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new viewBox: "0 0 700 70"
+svg = Victor::SVG.new viewBox: "0 0 700 70"
 
 svg.rect x: 0, y: 0, width: 700, height: 70, fill: '#ddd'
 svg.text "Victor", x: 100, y: 50, font_family: 'arial', font_weight: 'bold', font_size: 40, fill: 'blue'

--- a/examples/06_text.svg
+++ b/examples/06_text.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg viewBox="0 0 700 70" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 700 70" width="100%" height="100%" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/07_nested.rb
+++ b/examples/07_nested.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 420, height: 80
+svg = Victor::SVG.new width: 420, height: 80
 
 svg.build do
   rect x: 0, y: 0, width: 420, height: 80, fill: '#666'

--- a/examples/07_nested.svg
+++ b/examples/07_nested.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="420" height="80" xmlns="http://www.w3.org/2000/svg">
+<svg width="420" height="80" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/08_css.rb
+++ b/examples/08_css.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 200, height: 200, viewBox: "0 0 70 70", 
+svg = Victor::SVG.new width: 200, height: 200, viewBox: "0 0 70 70", 
   style: { background: '#eee' }
 
 svg.build do 

--- a/examples/08_css.svg
+++ b/examples/08_css.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="200" height="200" viewBox="0 0 70 70" style="background:#eee" xmlns="http://www.w3.org/2000/svg">
+<svg width="200" height="200" viewBox="0 0 70 70" style="background:#eee" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/09_pacman.rb
+++ b/examples/09_pacman.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 140, height: 100, style: { background: '#ddd' }
+svg = Victor::SVG.new width: 140, height: 100, style: { background: '#ddd' }
 
 svg.build do 
   rect x: 10, y: 10, width: 120, height: 80, rx: 10, fill: '#666'

--- a/examples/09_pacman.svg
+++ b/examples/09_pacman.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="140" height="100" style="background:#ddd" xmlns="http://www.w3.org/2000/svg">
+<svg width="140" height="100" style="background:#ddd" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/10_animation.rb
+++ b/examples/10_animation.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 140, height: 100, style: { background: '#ddd' }
+svg = Victor::SVG.new width: 140, height: 100, style: { background: '#ddd' }
 
 def animation
   css[".mouth"] = {

--- a/examples/10_animation.svg
+++ b/examples/10_animation.svg
@@ -1,7 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 
-<svg width="140" height="100" style="background:#ddd" xmlns="http://www.w3.org/2000/svg">
+<svg width="140" height="100" style="background:#ddd" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <style type="text/css">
 <![CDATA[

--- a/examples/11_def_pattern.rb
+++ b/examples/11_def_pattern.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 300, height: 300, viewBox:"0 0 400 300"
+svg = Victor::SVG.new width: 300, height: 300, viewBox:"0 0 400 300"
 
 svg.build do
   

--- a/examples/12_custom_fonts.rb
+++ b/examples/12_custom_fonts.rb
@@ -1,6 +1,6 @@
 require 'victor'
 
-svg = SVG.new width: 300, height: 180, viewBox:"0 0 300 180"
+svg = Victor::SVG.new width: 300, height: 180, viewBox:"0 0 300 180"
 
 svg.build do
   

--- a/lib/victor.rb
+++ b/lib/victor.rb
@@ -2,5 +2,3 @@ require 'victor/version'
 require 'victor/svg'
 require 'victor/attributes'
 require 'victor/css'
-
-include Victor

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ require 'rubygems'
 require 'bundler'
 Bundler.require :default, :development
 
+include Victor
+
 def fixture(filename, data=nil)
   if data
     File.write "spec/fixtures/#{filename}", data


### PR DESCRIPTION
Requiring `victor` added a forced `include Victor` at the top level, which is not very polite.

This PR removes this include and updates the examples and README accordingly.

Now people need to add `include Victor` to their code, or use `Victor::SVG.new` instead of just `SVG.new`

Closes #18 