### PR TITLE
Add ability to compose SVG from smaller SVG blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Another approach to a more modular SVG composition, would be to subclass
 
 See the [composite svg example](https://github.com/DannyBen/victor/tree/master/examples#13-composite-svg)
 or the [subclassing example](https://github.com/DannyBen/victor/tree/master/examples#14-subclassing-svg)
+for more details.
 
 
 Saving the Output

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ svg.text "Victor", x: 40, y: 50, font_family: 'arial', font_weight: 'bold', font
 Composite SVG
 --------------------------------------------------
 Victor also supports the abiliy to combine several smaller SVG objects into 
-one.
+one using the `<<` operator. This operator expects to receive any object
+that responds to `#to_s` (can be another `SVG` object).
 
 ```ruby
 require 'victor'

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ When the value of the CSS attribute is an array, Victor will simply use
 the values of the array and prefix each of them with the key, so the above 
 will result in two `@import url(...)` rows.
 
-See the [custom fonts example](https://github.com/DannyBen/victor/tree/master/examples#12-custom-fonts)
+See the [custom fonts example](https://github.com/DannyBen/victor/tree/master/examples#12-custom-fonts).
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Table of Contents
 * [Install](#install)
 * [Examples](#examples)
 * [Usage](#usage)
+* [Composite SVG](#composite-svg)
 * [Saving the Output](#saving-the-output)
 * [SVG Templates](#svg-templates)
 * [CSS](#css)
@@ -169,6 +170,45 @@ svg.text "Victor", x: 40, y: 50, font_family: 'arial', font_weight: 'bold', font
 #      Victor
 #    </text>
 ```
+
+Composite SVG
+--------------------------------------------------
+Victor also supports the abiliy to combine several smaller SVG objects into 
+one.
+
+```ruby
+require 'victor'
+include Victor
+
+# Create a reusable SVG object
+frame = SVG.new
+frame.rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
+frame.rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
+
+# ... and another
+troll = SVG.new
+troll.circle cx: 50, cy: 60, r: 24, fill: 'yellow'
+troll.polygon points: %w[24,50 50,14 76,54], fill: 'red'
+
+# Combine objects into a single image
+svg = SVG.new viewBox: '0 0 100 100'
+svg << frame
+svg << troll
+
+# ... and save it
+svg.save 'framed-troll'
+```
+
+Output:
+
+[![troll](https://cdn.rawgit.com/DannyBen/victor/master/examples/13_composite_svg.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/13_composite_svg.svg)
+
+Another approach to a more modular SVG composition, would be to subclass 
+`Victor::SVG`.
+
+See the [composite svg example](https://github.com/DannyBen/victor/tree/master/examples#13-composite-svg)
+or the [subclassing example](https://github.com/DannyBen/victor/tree/master/examples#14-subclassing-svg)
+
 
 Saving the Output
 --------------------------------------------------

--- a/examples/13_composite_svg.rb
+++ b/examples/13_composite_svg.rb
@@ -1,6 +1,7 @@
 require 'victor'
 include Victor
 
+# Create two reusable objects: frame and troll
 frame = SVG.new
 frame.rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
 frame.rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
@@ -9,6 +10,7 @@ troll = SVG.new
 troll.circle cx: 50, cy: 60, r: 24, fill: 'yellow'
 troll.polygon points: %w[24,50 50,14 76,54], fill: 'red'
 
+# Append the objects to a new SVG using the << operator
 svg = SVG.new viewBox: '0 0 100 100', width: 100, height: 100
 svg << frame
 svg << troll

--- a/examples/13_composite_svg.rb
+++ b/examples/13_composite_svg.rb
@@ -1,0 +1,16 @@
+require 'victor'
+include Victor
+
+frame = SVG.new
+frame.rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
+frame.rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
+
+troll = SVG.new
+troll.circle cx: 50, cy: 60, r: 24, fill: 'yellow'
+troll.polygon points: %w[24,50 50,14 76,54], fill: 'red'
+
+svg = SVG.new viewBox: '0 0 100 100', width: 100, height: 100
+svg << frame
+svg << troll
+
+svg.save '13_composite_svg'

--- a/examples/13_composite_svg.svg
+++ b/examples/13_composite_svg.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg viewBox="0 0 100 100" width="100" height="100" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
+<rect x="0" y="0" width="100" height="100" fill="#336"/>
+<rect x="10" y="10" width="80" height="80" fill="#fff"/>
+<circle cx="50" cy="60" r="24" fill="yellow"/>
+<polygon points="24,50 50,14 76,54" fill="red"/>
+
+</svg>

--- a/examples/14_subclassing.rb
+++ b/examples/14_subclassing.rb
@@ -1,0 +1,31 @@
+require 'victor'
+
+class Troll < Victor::SVG
+  attr_reader :color, :hat_color
+
+  def initialize(color: 'yellow', hat_color: 'red')
+    @color, @hat_color = color, hat_color
+    super width: 100, height: 100, viewBox: '0 0 100 100'
+
+    frame
+    head
+  end
+
+  def add_nose
+    circle cx: 50, cy: 65, r: 4, fill: 'black'
+  end
+
+  def frame
+    rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
+    rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
+  end
+
+  def head
+    circle cx: 50, cy: 60, r: 24, fill: color
+    polygon points: %w[24,50 50,14 76,54], fill: hat_color
+  end
+end
+
+troll = Troll.new color: '#33f', hat_color: '#3f3';
+troll.add_nose
+troll.save '14_subclassing'

--- a/examples/14_subclassing.rb
+++ b/examples/14_subclassing.rb
@@ -4,13 +4,16 @@ class Troll < Victor::SVG
   attr_reader :color, :hat_color
 
   def initialize(color: 'yellow', hat_color: 'red')
+    # Accept parameters we care about, and call the super initializer
     @color, @hat_color = color, hat_color
     super width: 100, height: 100, viewBox: '0 0 100 100'
 
+    # Generate the base image with the frame and head elements
     frame
     head
   end
 
+  # Allow adding more elements after instantiation
   def add_nose
     circle cx: 50, cy: 65, r: 4, fill: 'black'
   end

--- a/examples/14_subclassing.svg
+++ b/examples/14_subclassing.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg width="100" height="100" viewBox="0 0 100 100" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+<style type="text/css">
+<![CDATA[
+
+]]>
+</style>
+
+<rect x="0" y="0" width="100" height="100" fill="#336"/>
+<rect x="10" y="10" width="80" height="80" fill="#fff"/>
+<circle cx="50" cy="60" r="24" fill="#33f"/>
+<polygon points="24,50 50,14 76,54" fill="#3f3"/>
+<circle cx="50" cy="65" r="4" fill="black"/>
+
+</svg>

--- a/examples/README.md
+++ b/examples/README.md
@@ -340,6 +340,73 @@ svg.save '12_custom_fonts'
 [![12_custom_fonts](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/12_custom_fonts.svg)
 
 
+## 13 composite svg
+
+```ruby
+require 'victor'
+include Victor
+
+frame = SVG.new
+frame.rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
+frame.rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
+
+troll = SVG.new
+troll.circle cx: 50, cy: 60, r: 24, fill: 'yellow'
+troll.polygon points: %w[24,50 50,14 76,54], fill: 'red'
+
+svg = SVG.new viewBox: '0 0 100 100', width: 100, height: 100
+svg << frame
+svg << troll
+
+svg.save '13_composite_svg'
+```
+
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/13_composite_svg.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/13_composite_svg.svg)
+
+[![13_composite_svg](https://cdn.rawgit.com/DannyBen/victor/master/examples/13_composite_svg.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/13_composite_svg.svg)
+
+
+## 14 subclassing
+
+```ruby
+require 'victor'
+
+class Troll < Victor::SVG
+  attr_reader :color, :hat_color
+
+  def initialize(color: 'yellow', hat_color: 'red')
+    @color, @hat_color = color, hat_color
+    super width: 100, height: 100, viewBox: '0 0 100 100'
+
+    frame
+    head
+  end
+
+  def add_nose
+    circle cx: 50, cy: 65, r: 4, fill: 'black'
+  end
+
+  def frame
+    rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
+    rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
+  end
+
+  def head
+    circle cx: 50, cy: 60, r: 24, fill: color
+    polygon points: %w[24,50 50,14 76,54], fill: hat_color
+  end
+end
+
+troll = Troll.new color: '#33f', hat_color: '#3f3';
+troll.add_nose
+troll.save '14_subclassing'
+```
+
+[Open Source Ruby File](https://github.com/DannyBen/victor/blob/master/examples/14_subclassing.rb) | [Open Image](https://cdn.rawgit.com/DannyBen/victor/master/examples/14_subclassing.svg)
+
+[![14_subclassing](https://cdn.rawgit.com/DannyBen/victor/master/examples/14_subclassing.svg)](https://cdn.rawgit.com/DannyBen/victor/master/examples/14_subclassing.svg)
+
+
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -346,6 +346,7 @@ svg.save '12_custom_fonts'
 require 'victor'
 include Victor
 
+# Create two reusable objects: frame and troll
 frame = SVG.new
 frame.rect x: 0, y: 0, width: 100, height: 100, fill: '#336'
 frame.rect x: 10, y: 10, width: 80, height: 80, fill: '#fff'
@@ -354,6 +355,7 @@ troll = SVG.new
 troll.circle cx: 50, cy: 60, r: 24, fill: 'yellow'
 troll.polygon points: %w[24,50 50,14 76,54], fill: 'red'
 
+# Append the objects to a new SVG using the << operator
 svg = SVG.new viewBox: '0 0 100 100', width: 100, height: 100
 svg << frame
 svg << troll
@@ -375,13 +377,16 @@ class Troll < Victor::SVG
   attr_reader :color, :hat_color
 
   def initialize(color: 'yellow', hat_color: 'red')
+    # Accept parameters we care about, and call the super initializer
     @color, @hat_color = color, hat_color
     super width: 100, height: 100, viewBox: '0 0 100 100'
 
+    # Generate the base image with the frame and head elements
     frame
     head
   end
 
+  # Allow adding more elements after instantiation
   def add_nose
     circle cx: 50, cy: 65, r: 4, fill: 'black'
   end

--- a/lib/victor/svg.rb
+++ b/lib/victor/svg.rb
@@ -19,6 +19,10 @@ module Victor
       element method_sym, *arguments, &block
     end
 
+    def <<(additional_content)
+      content.push additional_content.to_s
+    end
+
     def build(&block)
       self.instance_eval(&block)
     end

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -22,6 +22,25 @@ describe SVG do
     end
   end
 
+  describe '#<<' do
+    it "pushes stringable objects as content" do
+      svg = SVG.new
+      fire = SVG.new
+      earth = SVG.new
+      water = SVG.new
+
+      fire.circle color: 'red'
+      earth.triangle color: 'green'
+      water.rect color: 'blue'
+
+      svg << fire
+      svg << earth
+      svg << water
+
+      expect(svg.to_s).to eq "<circle color=\"red\"/>\n<triangle color=\"green\"/>\n<rect color=\"blue\"/>"
+    end
+  end
+
   describe '#element' do
     it "generates xml without attributes" do
       svg.element 'anything'

--- a/victor.gemspec
+++ b/victor.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'filewatcher', '~> 1.0'
-  s.add_development_dependency 'byebug', '~> 9.1'
 end

--- a/victor.gemspec
+++ b/victor.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'filewatcher', '~> 1.0'
-  s.add_development_dependency 'byebug', '~> 10.0'
+  s.add_development_dependency 'byebug', '~> 9.1'
 end

--- a/victor.gemspec
+++ b/victor.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.6'
   s.add_development_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'filewatcher', '~> 1.0'
+  s.add_development_dependency 'byebug', '~> 10.0'
 end


### PR DESCRIPTION
This PR adds the ability to use `svg << other_svg` to append and compose an SVG image from other SVG objects.

- [x] Implementation
- [x] Test coverage
- [x] Documentation
- [x] Example for `<<`
- [x] Example for subclassing

Closes #26