### PR TITLE
Allow raw (unencoded) text

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Table of Contents
 * [SVG Templates](#svg-templates)
 * [CSS](#css)
 * [Tagless Elements](#tagless-elements)
+* [XML Encoding](#xml-encoding)
 * [Using with Rails](#using-with-rails)
 * [Related Projects](#related-projects)
 
@@ -348,6 +349,31 @@ end
 ```
 
 See the [targless elements example](https://github.com/DannyBen/victor/tree/master/examples#16-tagless-elements).
+
+
+XML Encoding
+--------------------------------------------------
+
+Plain text values are encoded automatically:
+
+```ruby
+svg.build do
+  text "Ben & Jerry's"
+end
+# <text>Ben &amp; Jerry's</text>
+```
+
+If you need to use the raw, unencoded string, add `!` to the element's name:
+
+```ruby
+svg.build do
+  text! "Ben & Jerry's"
+end
+# <text>Ben & Jerry's</text>
+```
+
+See the [xml encoding example](https://github.com/DannyBen/victor/tree/master/examples#17-xml-encoding).
+
 
 
 Using with Rails

--- a/examples/17_xml_encoding.rb
+++ b/examples/17_xml_encoding.rb
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require 'victor'
+include Victor
+
+svg = SVG.new viewBox: "0 0 100 50"
+
+svg.build do 
+  rect x: 0, y:0, width: 100, height: 50, style: { fill: '#ddd' }
+  text "Ben & Jerry's", x: 10, y: 10, font_size: 12
+  text! "&#x2714; Works!", x: 10, y: 25, font_size: 12
+end
+
+svg.save '17_xml_endcoding'
+

--- a/examples/17_xml_endcoding.svg
+++ b/examples/17_xml_endcoding.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg viewBox="0 0 100 50" width="100%" height="100%" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+
+<rect x="0" y="0" width="100" height="50" style="fill:#ddd"/>
+<text x="10" y="10" font-size="12">
+Ben &amp; Jerry's
+</text>
+<text! x="10" y="25" font-size="12">
+&amp;#x2714; Works!
+</text!>
+
+</svg>

--- a/examples/README.md
+++ b/examples/README.md
@@ -509,6 +509,29 @@ svg.save '16_tagless_elements'
 [![16_tagless_elements](/examples/16_tagless_elements.svg)](/examples/16_tagless_elements.svg)
 
 
+## 17 xml encoding
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'victor'
+include Victor
+
+svg = SVG.new viewBox: "0 0 100 50"
+
+svg.build do 
+  rect x: 0, y:0, width: 100, height: 50, style: { fill: '#ddd' }
+  text "Ben & Jerry's", x: 10, y: 10, font_size: 12
+  text! "&#x2714; Works!", x: 10, y: 25, font_size: 12
+end
+
+svg.save '17_xml_endcoding'
+```
+
+[View Source Ruby File](/examples/17_xml_encoding.rb)
+
+
+
 
 ---
 

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -28,12 +28,23 @@ module Victor
         value = nil
       end
 
+      escape = true
+
+      if name.to_s.end_with? '!'
+        escape = false
+        name = name[0..-2]
+      end
+
       attributes = Attributes.new attributes
       empty_tag = name.to_s == '_'
 
       if block_given? || value
         content.push "<#{name} #{attributes}".strip + ">" unless empty_tag
-        value ? content.push(value.to_s.encode(xml: :text)) : yield
+        if value
+          content.push(escape ? value.to_s.encode(xml: :text) : value)
+        else
+          yield
+        end
         content.push "</#{name}>" unless empty_tag
       else      
         content.push "<#{name} #{attributes}/>"

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -112,6 +112,20 @@ describe SVG do
           svg.element '_', 'For Dumb & Dumber, 2 > 3'
           expect(svg.content).to eq ["For Dumb &amp; Dumber, 2 &gt; 3"]
         end
+
+        context "when the element is _!" do
+          it "does not escape XML" do
+            svg.element '_!', 'For Dumb & Dumber, 2 > 3'
+            expect(svg.content).to eq ["For Dumb & Dumber, 2 > 3"]
+          end
+        end
+      end
+
+      context "when the element name ends with !" do
+        it "does not escape XML" do
+          svg.element 'text!', 'For Dumb & Dumber, 2 > 3'
+          expect(svg.content).to eq ["<text>", "For Dumb & Dumber, 2 > 3", "</text>"]
+        end
       end
     end
   end


### PR DESCRIPTION
Since #38, it was impossible to add raw (unescaped) XML, like `&#8697;`

This PR adds the ability to do so, by adding a bang to element names:

- `text "Ben & Jerry's"` will be encoded to `Ben &amp; Jerry's`
- `text! "&#x2714; Works!"` will be placed in teh XML as is
