### PR TITLE
Add block support to SVG.new

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,23 @@ svg << other
 svg.append other
 ```
 
+To make this common use case a little easier to use, you can use a block when instantiating a new `SVG` object:
+
+```ruby
+troll = SVG.new do
+  circle cx: 50, cy: 60, r: 24, fill: 'yellow'
+end
+```
+
+Which is the same as:
+
+```ruby
+troll = SVG.new
+troll.build do
+  circle cx: 50, cy: 60, r: 24, fill: 'yellow'
+end
+```
+
 Another approach to a more modular SVG composition, would be to subclass 
 `Victor::SVG`.
 

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -4,10 +4,11 @@ module Victor
     attr_accessor :template, :css
     attr_reader :content, :svg_attributes
 
-    def initialize(attributes = nil)
+    def initialize(attributes = nil, &block)
       setup attributes
       @content = []
       @css = {}
+      build &block if block_given?
     end
 
     def <<(additional_content)

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -20,6 +20,16 @@ describe SVG do
       svg = SVG.new dudes: { duke: :nukem, vanilla: :ice }
       expect(svg.svg_attributes.to_s).to match(/dudes="duke:nukem; vanilla:ice"/)
     end
+
+    context "when a block is given" do
+      it "builds with the block" do
+        svg = SVG.new do
+          circle cx: 10, cy: 10, r: 20
+        end
+
+        expect(svg.to_s).to eq "<circle cx=\"10\" cy=\"10\" r=\"20\"/>"
+      end
+    end
   end
 
   context 'append' do


### PR DESCRIPTION
This feature allows for an easier creation of composite SVGs, since it allows writing this:

```ruby
cloud = SVG.new build do
  # ...
end
```

as an alternative to this:

```ruby
cloud = SVG.new
cloud.build do
  # ...
end
```