### PR TITLE
Improve CSS accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,15 @@ CSS gets a special treatment in `Victor::SVG`, with these objectives in mind:
 - Provide a DSL-like syntax for CSS rules
 
 The `Victor::SVG` objects has a `css` property, which can contain either a 
-Hash or a String.
+Hash or a String:
 
 ```ruby
 svg = Victor::SVG.new
 
 svg.css = css_hash_or_string
+# or without the equal sign:
+svg.css css_hash_or_string
+
 svg.build do
   # ...
 end

--- a/lib/victor/dsl.rb
+++ b/lib/victor/dsl.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 module Victor
   module DSL
     extend Forwardable
-    def_delegators :svg, :setup, :build, :save, :render, :append, :element
+    def_delegators :svg, :setup, :build, :save, :render, :append, :element, :css
 
     def svg
       @svg ||= Victor::SVG.new

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -1,13 +1,12 @@
 module Victor
 
   class SVGBase
-    attr_accessor :template, :css
+    attr_accessor :template
     attr_reader :content, :svg_attributes
 
     def initialize(attributes = nil, &block)
       setup attributes
       @content = []
-      @css = {}
       build &block if block_given?
     end
 
@@ -63,13 +62,23 @@ module Victor
       end
     end
 
+    def css(defs = nil)
+      @css ||= {}
+      @css = defs if defs
+      @css
+    end
+
+    def css=(defs)
+      @css = defs
+    end
+
     def render(template: nil)
       @template = template if template
-      css_string = CSS.new css
+      css_handler = CSS.new css
 
       svg_template % {
-        css: css_string,
-        style: css_string.render,
+        css: css_handler,
+        style: css_handler.render,
         attributes: svg_attributes,
         content: content.join("\n")
       }

--- a/spec/victor/css_spec.rb
+++ b/spec/victor/css_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe CSS do
-  subject { described_class.new @css }
+  subject { described_class.new css }
+  let(:css) { {} }
 
   describe '#to_s' do
     it "converts css one level deep" do
-      @css = {}
-      @css['.main'] = {
+      css['.main'] = {
         color: 'black',
         background: 'white'
       }
@@ -15,8 +15,7 @@ describe CSS do
     end
 
     it "converts css several levels deep" do
-      @css = {}
-      @css["@keyframes animation"] = {
+      css["@keyframes animation"] = {
         "0%" => {
           font_size: "10px"
         },
@@ -29,8 +28,7 @@ describe CSS do
     end
 
     it "converts array values to single lines" do
-      @css = {}
-      @css['@import'] = [
+      css['@import'] = [
         "some url",
         "another url"
       ]
@@ -39,24 +37,28 @@ describe CSS do
     end
 
     context "when attributes are not a hash" do
+      let(:css) { ".class { color: blue }" }
+
       it "returns the attributes as is" do
-        @css = ".class { color: blue }"
-        expect(subject.to_s).to eq @css
+        expect(subject.to_s).to eq css
       end
     end
   end
 
   describe '#render' do
+    let(:css) { { '.main' => { color: 'black' } } }
+
     it "returns the css string wrapped inside style tags" do
-      @css = { '.main' => { color: 'black' } }
       expect(subject.render).to match_approval 'css/render'
     end
 
     context "when the css is empty" do
+      let(:css) { {} }
+
       it "returns an empty string" do
         expect(subject.render).to be_empty
       end
-    end        
+    end
   end
 
 end

--- a/spec/victor/dsl_spec.rb
+++ b/spec/victor/dsl_spec.rb
@@ -37,4 +37,11 @@ describe DSL do
     end
   end
 
+  describe '#css' do
+    it "forwards the call to the svg object" do
+      expect(subject.svg).to receive(:css)
+      subject.css
+    end
+  end
+
 end

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -175,6 +175,36 @@ describe SVG do
     end
   end
 
+  describe '#css' do
+    context "when no css rules were added" do
+      it "returns an empty hash" do
+        expect(subject.css).to eq({})
+      end
+    end
+
+    context "when css rules were added" do
+      before { subject.css = { fill: 'blue' } }
+
+      it "returns the rules (hash or string)" do
+        expect(subject.css[:fill]).to eq 'blue'
+      end
+
+      context "with an argument" do
+        it "replaces the entire css attribute" do
+          subject.css color: 'red'
+          expect(subject.css).to eq({ color: 'red' })
+        end
+      end
+    end
+  end
+  
+  describe '#css=' do
+    it "replaces the entire css attribute" do
+      subject.css = { color: 'red' }
+      expect(subject.css[:color]).to eq 'red'
+    end
+  end
+
   describe '#method_missing' do
     it "calls #element" do
       expect(subject).to receive(:element).with(:anything)


### PR DESCRIPTION
This PR fixes and improves the possible ways to set CSS.

- The DSL (used by the CLI) now also delegates the `css` method to the SVG object, so DSL scripts can simply use `css['.selector'] = ..` as opposed to the need to use `svg.css['.selector'] = ...` before this PR.
- The `SVG_Base#css` accessor was modified so that it can now accept optional argument, which will make it behave like `SVG_Base#css=`. This also makes the DSL more natural.