### PR TITLE
Refactor SVGBase with a new Element class

### DIFF
--- a/Runfile
+++ b/Runfile
@@ -103,5 +103,4 @@ action :changelog do
   run "cat .changelog.old.md >> CHANGELOG.md"
 end
 
-
 require_relative 'debug.rb' if File.exist? 'debug.rb'

--- a/Runfile
+++ b/Runfile
@@ -104,3 +104,4 @@ action :changelog do
 end
 
 require_relative 'debug.rb' if File.exist? 'debug.rb'
+

--- a/Runfile
+++ b/Runfile
@@ -104,4 +104,3 @@ action :changelog do
 end
 
 require_relative 'debug.rb' if File.exist? 'debug.rb'
-

--- a/lib/victor.rb
+++ b/lib/victor.rb
@@ -1,4 +1,5 @@
 require 'victor/version'
+require 'victor/element'
 require 'victor/svg_base'
 require 'victor/svg'
 require 'victor/attributes'

--- a/lib/victor/element.rb
+++ b/lib/victor/element.rb
@@ -22,15 +22,11 @@ module Victor
     end
 
     def render(&block)
-      result = []
-
       if block_given? || value
-        result += wrap_element &block
+        wrap_element &block
       else      
-        result.push "<#{name} #{attributes}/>"
+        ["<#{name} #{attributes}/>"]
       end
-
-      result
     end
 
   private

--- a/lib/victor/element.rb
+++ b/lib/victor/element.rb
@@ -21,17 +21,11 @@ module Victor
       end
     end
 
-    def render
+    def render(&block)
       result = []
 
       if block_given? || value
-        result.push "<#{name} #{attributes}".strip + ">" unless empty_tag?
-        if value
-          result.push(escape ? value.to_s.encode(xml: :text) : value)
-        else
-          result += yield
-        end
-        result.push "</#{name}>" unless empty_tag?
+        result += wrap_element &block
       else      
         result.push "<#{name} #{attributes}/>"
       end
@@ -43,6 +37,22 @@ module Victor
 
     def empty_tag?
       name.to_s == '_'
+    end
+
+    def wrap_element
+      result = []
+
+      result.push "<#{name} #{attributes}".strip + ">" unless empty_tag?
+      
+      if value
+        result.push(escape ? value.to_s.encode(xml: :text) : value)
+      else
+        result += yield
+      end
+      
+      result.push "</#{name}>" unless empty_tag?
+
+      result
     end
 
   end

--- a/lib/victor/element.rb
+++ b/lib/victor/element.rb
@@ -1,0 +1,49 @@
+module Victor
+
+  class Element
+    attr_reader :name, :value, :attributes, :escape
+
+    def initialize(name, value_or_attributes = nil, attributes = {})
+      if value_or_attributes.is_a? Hash
+        @attributes = Attributes.new value_or_attributes
+        @value = nil
+      else
+        @value = value_or_attributes
+        @attributes = Attributes.new attributes
+      end
+
+      if name.to_s.end_with? '!'
+        @escape = false
+        @name = name[0..-2]
+      else
+        @escape = true
+        @name = name
+      end
+    end
+
+    def render
+      result = []
+
+      if block_given? || value
+        result.push "<#{name} #{attributes}".strip + ">" unless empty_tag?
+        if value
+          result.push(escape ? value.to_s.encode(xml: :text) : value)
+        else
+          result += yield
+        end
+        result.push "</#{name}>" unless empty_tag?
+      else      
+        result.push "<#{name} #{attributes}/>"
+      end
+
+      result
+    end
+
+  private
+
+    def empty_tag?
+      name.to_s == '_'
+    end
+
+  end
+end

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -33,33 +33,8 @@ module Victor
       self.instance_eval(&block)
     end
 
-    def element(name, value=nil, attributes={}, &_block)
-      if value.is_a? Hash
-        attributes = value
-        value = nil
-      end
-
-      escape = true
-
-      if name.to_s.end_with? '!'
-        escape = false
-        name = name[0..-2]
-      end
-
-      attributes = Attributes.new attributes
-      empty_tag = name.to_s == '_'
-
-      if block_given? || value
-        content.push "<#{name} #{attributes}".strip + ">" unless empty_tag
-        if value
-          content.push(escape ? value.to_s.encode(xml: :text) : value)
-        else
-          yield
-        end
-        content.push "</#{name}>" unless empty_tag
-      else      
-        content.push "<#{name} #{attributes}/>"
-      end
+    def element(name, value=nil, attributes={}, &block)
+      @content += Element.new(name, value, attributes).render &block
     end
 
     def css(defs = nil)

--- a/spec/victor/element_spec.rb
+++ b/spec/victor/element_spec.rb
@@ -10,7 +10,6 @@ describe Element do
         expect(subject.name).to eq "circle"
         expect(subject.attributes).to be_an Attributes
         expect(subject.value).to be_nil
-        expect(subject.escape).to be true
       end
     end
 
@@ -21,7 +20,6 @@ describe Element do
         expect(subject.name).to eq "circle"
         expect(subject.attributes.attributes).to eq({})
         expect(subject.value).to eq "round"
-        expect(subject.escape).to be true
       end
     end
 
@@ -32,7 +30,6 @@ describe Element do
         expect(subject.name).to eq "circle"
         expect(subject.attributes[:border]).to eq 1
         expect(subject.value).to eq "round"
-        expect(subject.escape).to be true
       end
     end
 
@@ -43,19 +40,26 @@ describe Element do
         expect(subject.name).to eq "circle"
         expect(subject.attributes[:border]).to eq 1
         expect(subject.value).to be_nil
-        expect(subject.escape).to be true
       end
     end
 
     context "with a name that ends with !" do
-      subject { described_class.new "circle!" }
-
-      it "sets escape to false" do
-        expect(subject.escape).to be false
-      end
+      subject { described_class.new "circle!", "Dumb & Dumber" }
 
       it "removes the ! from the name" do
         expect(subject.name).to eq "circle"
+      end
+
+      it "does not escape the value" do
+        expect(subject.value).to eq "Dumb & Dumber"
+      end
+    end
+
+    context "with a value that contains special characters" do
+      subject { described_class.new "circle", "Dumb & Dumber" }
+
+      it "escapes the value" do
+        expect(subject.value).to eq "Dumb &amp; Dumber"
       end
     end
   end

--- a/spec/victor/element_spec.rb
+++ b/spec/victor/element_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe Element do
+
+  describe '::new' do
+    context "with name only" do
+      subject { described_class.new "circle" }
+
+      it "properly sets all instance variables" do
+        expect(subject.name).to eq "circle"
+        expect(subject.attributes).to be_an Attributes
+        expect(subject.value).to be_nil
+        expect(subject.escape).to be true
+      end
+    end
+
+    context "with name, value" do
+      subject { described_class.new "circle", "round" }
+
+      it "properly sets all instance variables" do
+        expect(subject.name).to eq "circle"
+        expect(subject.attributes.attributes).to eq({})
+        expect(subject.value).to eq "round"
+        expect(subject.escape).to be true
+      end
+    end
+
+    context "with name, value, attributes" do
+      subject { described_class.new "circle", "round", border: 1 }
+
+      it "properly sets all instance variables" do
+        expect(subject.name).to eq "circle"
+        expect(subject.attributes[:border]).to eq 1
+        expect(subject.value).to eq "round"
+        expect(subject.escape).to be true
+      end
+    end
+
+    context "with name, attributes" do
+      subject { described_class.new "circle", border: 1 }
+
+      it "properly sets all instance variables" do
+        expect(subject.name).to eq "circle"
+        expect(subject.attributes[:border]).to eq 1
+        expect(subject.value).to be_nil
+        expect(subject.escape).to be true
+      end
+    end
+
+    context "with a name that ends with !" do
+      subject { described_class.new "circle!" }
+
+      it "sets escape to false" do
+        expect(subject.escape).to be false
+      end
+
+      it "removes the ! from the name" do
+        expect(subject.name).to eq "circle"
+      end
+    end
+  end
+
+  describe '#render' do
+    context "with a value" do
+      subject { described_class.new "circle", "round" }
+
+      it "returns an array of element parts" do
+        expect(subject.render).to eq ["<circle>", "round", "</circle>"]
+      end
+    end
+
+    context "with a block" do
+      subject { described_class.new "circle" }
+
+      it "returns an array of element parts" do
+        expect(subject.render { ["inside content"] }).to eq ["<circle>", "inside content", "</circle>"]
+      end
+    end
+
+    context "without a block or a value" do
+      subject { described_class.new "circle", border: 1 }
+
+      it "returns an array of element parts" do
+        expect(subject.render).to eq ['<circle border="1"/>']
+      end
+    end
+  end
+
+end

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SVG do
-  describe '#new' do
+  describe '::new' do
     it "sets default attributes" do
       expect(subject.svg_attributes[:height]).to eq "100%"
       expect(subject.svg_attributes[:width]).to eq "100%"


### PR DESCRIPTION
The `SVGBase` class had an obvious code smell in its long `#element` method.

Its functionality as extracted to a new `Element` class.