### PR TITLE
Add specs to ensure block return value is ignored

### DIFF
--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -134,6 +134,17 @@ describe SVG do
         end
         expect(subject.content).to eq ["<universe>", "<world>", "<me />", "</world>", "</universe>"]
       end
+
+      it "ignores the block's return value", :focus do
+        subject.build do
+          element :group do
+            element :one
+            element :two
+            element :three if false
+          end
+        end
+        expect(subject.content).to eq ["<group>", "<one />", "<two />", "</group>"]
+      end
     end
 
     context "with a plain text value" do

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -135,7 +135,10 @@ describe SVG do
         expect(subject.content).to eq ["<universe>", "<world>", "<me />", "</world>", "</universe>"]
       end
 
-      it "ignores the block's return value", :focus do
+      # This test is done since cases like this were not covered which caused
+      # a passing build to actually be broken
+      # https://github.com/DannyBen/victor/pull/59
+      it "ignores the block's return value" do
         subject.build do
           element :group do
             element :one


### PR DESCRIPTION
This PR: https://github.com/DannyBen/victor/pull/59

Was passing tests, but had a bug that caused [minicharts](https://github.com/DannyBen/minichart) to fail catastrophically.

The original PR was not released, but we were forced to rollback the change.

This PR adds tests for that particular use case, and ensures that the return value of a build block is not impacting the rendering in any way.