### PR TITLE
Allow Victor::SVG to be marshaled

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,11 @@ Style/MixinUsage:
     - 'examples/*'
     - lib/victor/script.rb
 
+# We use Marshal.load to test that it *can* be done. Allow it.
+Security/MarshalLoad:
+  Exclude:
+    - spec/victor/svg_marshaling_spec.rb
+
 RSpec/ExampleLength:
   Exclude:
     - spec/victor/svg_spec.rb

--- a/lib/victor.rb
+++ b/lib/victor.rb
@@ -1,4 +1,5 @@
 require 'victor/version'
+require 'victor/marshaling'
 require 'victor/svg_base'
 require 'victor/svg'
 require 'victor/attributes'

--- a/lib/victor/marshaling.rb
+++ b/lib/victor/marshaling.rb
@@ -1,5 +1,6 @@
 module Victor
   module Marshaling
+    # YAML serialization methods
     def encode_with(coder)
       coder['content'] = @content
       coder['glue'] = @glue

--- a/lib/victor/marshaling.rb
+++ b/lib/victor/marshaling.rb
@@ -1,0 +1,38 @@
+module Victor
+  module Marshaling
+    def encode_with(coder)
+      coder['content'] = @content
+      coder['glue'] = @glue
+      coder['svg_attributes'] = @svg_attributes
+      coder['template'] = @template
+      coder['css'] = @css
+    end
+
+    def init_with(coder)
+      @content = coder['content']
+      @glue = coder['glue']
+      @svg_attributes = coder['svg_attributes']
+      @template = coder['template']
+      @css = coder['css']
+    end
+
+    # Marshal serialization methods
+    def marshal_dump
+      {
+        content:        @content,
+        glue:           @glue,
+        svg_attributes: @svg_attributes,
+        template:       @template,
+        css:            @css,
+      }
+    end
+
+    def marshal_load(data)
+      @content = data[:content]
+      @glue = data[:glue]
+      @svg_attributes = data[:svg_attributes]
+      @template = data[:template]
+      @css = data[:css]
+    end
+  end
+end

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -1,5 +1,7 @@
 module Victor
   class SVGBase
+    include Marshaling
+
     attr_accessor :template, :glue
     attr_reader :content, :svg_attributes
     attr_writer :css

--- a/spec/victor/svg_marshaling_spec.rb
+++ b/spec/victor/svg_marshaling_spec.rb
@@ -27,5 +27,5 @@ describe Victor::SVG do
       expect(restored_object).to be_a described_class
       expect(restored_object.render).to eq subject.render
     end
-  end  
+  end
 end

--- a/spec/victor/svg_marshalling_spec.rb
+++ b/spec/victor/svg_marshalling_spec.rb
@@ -1,0 +1,31 @@
+require 'yaml'
+
+describe Victor::SVG do
+  subject do
+    described_class.new viewBox: '0 0 10 100' do
+      text 'Hello world'
+      rect x: 0, y: 0, width: 10, height: 100
+      css['*'] = { font_family: 'Assistant' }
+    end
+  end
+
+  describe 'YAML marshaling' do
+    it 'serializes and deserializes correctly using YAML' do
+      yaml_data = YAML.dump subject
+      restored_object = YAML.unsafe_load yaml_data
+
+      expect(restored_object).to be_a described_class
+      expect(restored_object.render).to eq subject.render
+    end
+  end
+
+  describe 'Ruby marshaling' do
+    it 'serializes and deserializes correctly using Marshal' do
+      marshaled_data = Marshal.dump subject
+      restored_object = Marshal.load marshaled_data
+
+      expect(restored_object).to be_a described_class
+      expect(restored_object.render).to eq subject.render
+    end
+  end  
+end


### PR DESCRIPTION
Since marshaling can be very useful for keeping a "YAML copy" of the generated image, for later use (e.g. embedding), this PR ensures that both YAML and Ruby marshaling works properly and consistently. 