### PR TITLE
Add `Victor::Component` for component-driven SVG composition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
   TargetRubyVersion: 3.0
   SuggestExtensions: false
   Exclude:
-    - 'dev/*'
+    - 'dev/**/*'
 
 # There is a special use case that needs this
 Lint/LiteralAsCondition:

--- a/lib/victor.rb
+++ b/lib/victor.rb
@@ -1,4 +1,4 @@
-autoload :VERSION, 'victor/version'
+require 'victor/version'
 
 module Victor
   autoload :Attributes, 'victor/attributes'

--- a/lib/victor.rb
+++ b/lib/victor.rb
@@ -1,7 +1,11 @@
-require 'victor/version'
-require 'victor/marshaling'
-require 'victor/svg_base'
-require 'victor/svg'
-require 'victor/attributes'
-require 'victor/css'
-require 'victor/dsl'
+autoload :VERSION, 'victor/version'
+
+module Victor
+  autoload :Attributes, 'victor/attributes'
+  autoload :Component, 'victor/component'
+  autoload :CSS, 'victor/css'
+  autoload :DSL, 'victor/dsl'
+  autoload :Marshaling, 'victor/marshaling'
+  autoload :SVG, 'victor/svg'
+  autoload :SVGBase, 'victor/svg_base'
+end

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -1,0 +1,45 @@
+module Victor
+  class Component
+    # Subclasses MUST implement this
+    def body = raise(NotImplementedError, "#{self.class.name} must implement `body'")
+
+    # Subclasses MUST override these methods, OR assign instance vars
+    def height = @height || raise(NotImplementedError, "#{self.class.name} height or @height")
+    def width = @width || raise(NotImplementedError, "#{self.class.name} width or @width")
+    
+    # Subclasses MAY implement these methods
+    def style = {}
+
+    # Subclasses MAY override these methods, OR assign instance vars
+    def x = @x ||= 0
+    def y = @y ||= 0
+
+    # Rendering
+    def render = svg.render
+    alias to_s render
+    def save(...) = svg.save(...)
+
+    # SVG
+    def vector = @vector ||= SVG.new(viewBox: "#{x} #{y} #{width} #{height}")
+    alias add vector
+
+    # Appending/Embedding
+    def append(component)
+      vector.append component.svg
+      css.merge! component.style
+    end
+    alias embed append
+
+  protected
+
+    def css = @css ||= style.dup
+
+    def svg
+      @svg ||= begin
+        body
+        vector.css = css
+        vector
+      end
+    end
+  end
+end

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -20,7 +20,7 @@ module Victor
       @width || raise(NotImplementedError,
         "#{self.class.name} must implement `width' or `@width'")
     end
-    
+
     # Subclasses MAY override these methods, OR assign instance vars
     def style = @style ||= {}
     def x = @x ||= 0

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -6,11 +6,20 @@ module Victor
     def marshaling = %i[width height x y svg css]
 
     # Subclasses MUST implement this
-    def body = raise(NotImplementedError, "#{self.class.name} must implement `body'")
+    def body
+      raise(NotImplementedError, "#{self.class.name} must implement `body'")
+    end
 
     # Subclasses MUST override these methods, OR assign instance vars
-    def height = @height || raise(NotImplementedError, "#{self.class.name} height or @height")
-    def width = @width || raise(NotImplementedError, "#{self.class.name} width or @width")
+    def height
+      @height || raise(NotImplementedError,
+        "#{self.class.name} must implement `height' or `@height'")
+    end
+
+    def width
+      @width || raise(NotImplementedError,
+        "#{self.class.name} must implement `width' or `@width'")
+    end
     
     # Subclasses MAY override these methods, OR assign instance vars
     def style = @style ||= {}
@@ -18,13 +27,14 @@ module Victor
     def y = @y ||= 0
 
     # Rendering
-    def render = svg.render
-    alias to_s render
     def save(...) = svg.save(...)
+    def render(...) = svg.render(...)
+    def to_s = render
 
     # SVG
     def vector = @vector ||= SVG.new(viewBox: "#{x} #{y} #{width} #{height}")
     alias add vector
+
     def svg
       @svg ||= begin
         body

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -3,7 +3,7 @@ module Victor
     include Marshaling
 
     # Marshaling data
-    def marshaling = %i[width height x y svg css]
+    def marshaling = %i[width height x y svg merged_css]
 
     # Subclasses MUST implement this
     def body
@@ -32,27 +32,33 @@ module Victor
     def content = svg.content
     def to_s = render
 
-    # Appending/Embedding
+    # Appending/Embedding - DSL for the `#body` implementation
     def append(component)
-      vector.append component.svg
-      css.merge! component.css
+      svg_instance.append component.svg
+      merged_css.merge! component.merged_css
     end
     alias embed append
 
-  protected
-
-    # SVG
-    def vector = @vector ||= SVG.new(viewBox: "#{x} #{y} #{width} #{height}")
-    alias add vector
+    # SVG / CSS
     def svg
       @svg ||= begin
         body
-        vector.css = css
-        vector
+        svg_instance.css = merged_css
+        svg_instance
       end
     end
 
-    # CSS
-    def css = @css ||= style.dup
+    def css = @css ||= svg.css
+
+  protected
+
+    # Start with an ordinary SVG instance
+    def svg_instance = @svg_instance ||= SVG.new(viewBox: "#{x} #{y} #{width} #{height}")
+
+    # Internal DSL to enable `add.anything` in the `#body` implementation
+    alias add svg_instance
+
+    # Start with a copy of our own style
+    def merged_css = @merged_css ||= style.dup
   end
 end

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -1,5 +1,10 @@
 module Victor
   class Component
+    include Marshaling
+
+    # Marshaling data
+    def marshaling = %i[width height x y svg css]
+
     # Subclasses MUST implement this
     def body = raise(NotImplementedError, "#{self.class.name} must implement `body'")
 
@@ -7,10 +12,8 @@ module Victor
     def height = @height || raise(NotImplementedError, "#{self.class.name} height or @height")
     def width = @width || raise(NotImplementedError, "#{self.class.name} width or @width")
     
-    # Subclasses MAY implement these methods
-    def style = {}
-
     # Subclasses MAY override these methods, OR assign instance vars
+    def style = @style ||= {}
     def x = @x ||= 0
     def y = @y ||= 0
 
@@ -22,18 +25,6 @@ module Victor
     # SVG
     def vector = @vector ||= SVG.new(viewBox: "#{x} #{y} #{width} #{height}")
     alias add vector
-
-    # Appending/Embedding
-    def append(component)
-      vector.append component.svg
-      css.merge! component.style
-    end
-    alias embed append
-
-  protected
-
-    def css = @css ||= style.dup
-
     def svg
       @svg ||= begin
         body
@@ -41,5 +32,15 @@ module Victor
         vector
       end
     end
+
+    # CSS
+    def css = @css ||= style.dup
+
+    # Appending/Embedding
+    def append(component)
+      vector.append component.svg
+      css.merge! component.css
+    end
+    alias embed append
   end
 end

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -5,7 +5,7 @@ module Victor
     extend Forwardable
     include Marshaling
 
-    def_delegators :svg, :save, :render, :content, :element, :to_s
+    def_delegators :svg, :save, :render, :content, :element, :css, :to_s
 
     # Marshaling data
     def marshaling = %i[width height x y svg merged_css]
@@ -46,8 +46,6 @@ module Victor
         svg_instance
       end
     end
-
-    def css = @css ||= svg.css
 
   protected
 

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -1,6 +1,11 @@
+require 'forwardable'
+
 module Victor
   class Component
+    extend Forwardable
     include Marshaling
+
+    def_delegators :svg, :save, :render, :content, :element, :to_s
 
     # Marshaling data
     def marshaling = %i[width height x y svg merged_css]
@@ -25,12 +30,6 @@ module Victor
     def style = @style ||= {}
     def x = @x ||= 0
     def y = @y ||= 0
-
-    # Rendering
-    def save(...) = svg.save(...)
-    def render(...) = svg.render(...)
-    def content = svg.content
-    def to_s = render
 
     # Appending/Embedding - DSL for the `#body` implementation
     def append(component)

--- a/lib/victor/component.rb
+++ b/lib/victor/component.rb
@@ -29,12 +29,21 @@ module Victor
     # Rendering
     def save(...) = svg.save(...)
     def render(...) = svg.render(...)
+    def content = svg.content
     def to_s = render
+
+    # Appending/Embedding
+    def append(component)
+      vector.append component.svg
+      css.merge! component.css
+    end
+    alias embed append
+
+  protected
 
     # SVG
     def vector = @vector ||= SVG.new(viewBox: "#{x} #{y} #{width} #{height}")
     alias add vector
-
     def svg
       @svg ||= begin
         body
@@ -45,12 +54,5 @@ module Victor
 
     # CSS
     def css = @css ||= style.dup
-
-    # Appending/Embedding
-    def append(component)
-      vector.append component.svg
-      css.merge! component.css
-    end
-    alias embed append
   end
 end

--- a/lib/victor/marshaling.rb
+++ b/lib/victor/marshaling.rb
@@ -2,38 +2,28 @@ module Victor
   module Marshaling
     # YAML serialization methods
     def encode_with(coder)
-      coder['template'] = @template
-      coder['glue'] = @glue
-      coder['svg_attributes'] = @svg_attributes
-      coder['css'] = @css
-      coder['content'] = @content
+      marshaling.each do |attr|
+        coder[attr.to_s] = send(attr)
+      end
     end
 
     def init_with(coder)
-      @template = coder['template']
-      @glue = coder['glue']
-      @svg_attributes = coder['svg_attributes']
-      @css = coder['css']
-      @content = coder['content']
+      marshaling.each do |attr|
+        instance_variable_set(:"@#{attr}", coder[attr.to_s])
+      end
     end
 
     # Marshal serialization methods
     def marshal_dump
-      {
-        template:       @template,
-        glue:           @glue,
-        svg_attributes: @svg_attributes,
-        css:            @css,
-        content:        @content,
-      }
+      marshaling.to_h do |attr|
+        [attr, send(attr)]
+      end
     end
 
     def marshal_load(data)
-      @template = data[:template]
-      @glue = data[:glue]
-      @svg_attributes = data[:svg_attributes]
-      @css = data[:css]
-      @content = data[:content]
+      marshaling.each do |attr|
+        instance_variable_set(:"@#{attr}", data[attr])
+      end
     end
   end
 end

--- a/lib/victor/marshaling.rb
+++ b/lib/victor/marshaling.rb
@@ -1,5 +1,9 @@
 module Victor
   module Marshaling
+    def marshaling
+      raise NotImplementedError, "#{self.class.name} must implement `marshaling'"
+    end
+
     # YAML serialization methods
     def encode_with(coder)
       marshaling.each do |attr|

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -12,6 +12,10 @@ module Victor
       build(&block) if block
     end
 
+    def marshaling
+      %i[template glue svg_attributes css content]
+    end
+
     def <<(additional_content)
       content.push additional_content.to_s
     end

--- a/lib/victor/svg_base.rb
+++ b/lib/victor/svg_base.rb
@@ -20,6 +20,7 @@ module Victor
       content.push additional_content.to_s
     end
     alias append <<
+    alias embed <<
 
     def setup(attributes = nil)
       attributes ||= {}

--- a/lib/victor/templates/default.svg
+++ b/lib/victor/templates/default.svg
@@ -1,8 +1,4 @@
-<svg %{attributes} 
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-
+<svg %{attributes} xmlns="http://www.w3.org/2000/svg">
 %{style}
 %{content}
-
 </svg>

--- a/spec/approvals/component/set1/render
+++ b/spec/approvals/component/set1/render
@@ -14,8 +14,13 @@
   }
 </style>
 
+<g transform="translate(10, 10)">
+<text>
+Two
+</text>
 <text>
 Tada
 </text>
+</g>
 
 </svg>

--- a/spec/approvals/component/set1/render
+++ b/spec/approvals/component/set1/render
@@ -1,7 +1,4 @@
-<svg viewBox="0 0 100 100" width="100%" height="100%" 
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-
+<svg viewBox="0 0 100 100" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
 <style>
   .one {
     stroke: magenta;
@@ -22,5 +19,4 @@ Two
 Tada
 </text>
 </g>
-
 </svg>

--- a/spec/approvals/component/set1/render
+++ b/spec/approvals/component/set1/render
@@ -1,0 +1,21 @@
+<svg viewBox="0 0 100 100" width="100%" height="100%" 
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+<style>
+  .one {
+    stroke: magenta;
+  }
+  .two {
+    stroke: magenta;
+  }
+  .three {
+    stroke: magenta;
+  }
+</style>
+
+<text>
+Tada
+</text>
+
+</svg>

--- a/spec/approvals/svg/css
+++ b/spec/approvals/svg/css
@@ -1,7 +1,4 @@
-<svg width="100%" height="100%" 
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
 <style>
   .main {
     stroke: green;
@@ -11,5 +8,4 @@
 
 <circle radius="10"/>
 <circle radius="20"/>
-
 </svg>

--- a/spec/approvals/svg/full
+++ b/spec/approvals/svg/full
@@ -1,9 +1,5 @@
-<svg width="100%" height="100%" 
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
 
 <circle radius="10"/>
 <circle radius="20"/>
-
 </svg>

--- a/spec/approvals/svg/glue
+++ b/spec/approvals/svg/glue
@@ -1,8 +1,4 @@
-<svg width="100%" height="100%" 
-  xmlns="http://www.w3.org/2000/svg"
-  xmlns:xlink="http://www.w3.org/1999/xlink">
-
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
 
 <circle radius="10"/><circle radius="20"/>
-
 </svg>

--- a/spec/fixtures/components/component_set1.rb
+++ b/spec/fixtures/components/component_set1.rb
@@ -5,17 +5,24 @@ module ComponentSet1
   end
 
   class Main < Base
-    def body = append(Two.new)
+    def body
+      add.g transform: 'translate(10, 10)' do
+        append Two.new
+      end
+    end
     def style = { '.one': { stroke: :magenta } }
   end
 
   class Two < Base
-    def body = append(Three.new)
+    def body
+      add.text 'Two'
+      append Three.new
+    end
     def style = { '.two': { stroke: :magenta } }
   end
 
   class Three < Base
-    def body = add.text('Tada')
+    def body = add.text 'Tada'
     def style = { '.three': { stroke: :magenta } }
   end
 end

--- a/spec/fixtures/components/component_set1.rb
+++ b/spec/fixtures/components/component_set1.rb
@@ -10,6 +10,7 @@ module ComponentSet1
         append Two.new
       end
     end
+
     def style = { '.one': { stroke: :magenta } }
   end
 
@@ -18,11 +19,15 @@ module ComponentSet1
       add.text 'Two'
       append Three.new
     end
+
     def style = { '.two': { stroke: :magenta } }
   end
 
   class Three < Base
-    def body = add.text 'Tada'
+    def body
+      add.text 'Tada'
+    end
+
     def style = { '.three': { stroke: :magenta } }
   end
 end

--- a/spec/fixtures/components/component_set1.rb
+++ b/spec/fixtures/components/component_set1.rb
@@ -1,0 +1,21 @@
+module ComponentSet1
+  class Base < Victor::Component
+    def width = 100
+    def height = 100
+  end
+
+  class Main < Base
+    def body = append(Two.new)
+    def style = { '.one': { stroke: :magenta } }
+  end
+
+  class Two < Base
+    def body = append(Three.new)
+    def style = { '.two': { stroke: :magenta } }
+  end
+
+  class Three < Base
+    def body = add.text('Tada')
+    def style = { '.three': { stroke: :magenta } }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ unless ENV['NOCOV']
   SimpleCov.start do
     enable_coverage :branch if ENV['BRANCH_COV']
     coverage_dir 'spec/coverage'
-    track_files 'lib/**/*.rb'
+    # track_files 'lib/**/*.rb'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ unless ENV['NOCOV']
   SimpleCov.start do
     enable_coverage :branch if ENV['BRANCH_COV']
     coverage_dir 'spec/coverage'
-    # track_files 'lib/**/*.rb'
+    track_files 'lib/**/*.rb'
   end
 end
 

--- a/spec/victor/component_spec.rb
+++ b/spec/victor/component_spec.rb
@@ -71,14 +71,14 @@ describe Victor::Component do
     end
 
     describe '#append' do
-      let(:component) { double svg: 'mocked_svg', css: { color: 'red' } }
-      let(:vector) { double append: true }
-      let(:css) { double merge!: true }
+      let(:component) { double svg: 'mocked_svg', merged_css: { color: 'red' } }
+      let(:svg_instance) { double append: true }
+      let(:merged_css) { double merge!: true }
 
       it 'appends another component and merges its css' do
-        allow(subject).to receive_messages(vector: vector, css: css)
-        expect(vector).to receive(:append).with('mocked_svg')
-        expect(css).to receive(:merge!).with({ color: 'red' })
+        allow(subject).to receive_messages(svg_instance: svg_instance, merged_css: merged_css)
+        expect(svg_instance).to receive(:append).with('mocked_svg')
+        expect(merged_css).to receive(:merge!).with({ color: 'red' })
 
         subject.append component
       end

--- a/spec/victor/component_spec.rb
+++ b/spec/victor/component_spec.rb
@@ -36,37 +36,47 @@ describe Victor::Component do
   end
 
   context 'when all required methods are implemented' do
+    let(:svg) do
+      double save: true, render: true, content: true, element: true, to_s: true
+    end
+
     before do
       allow(subject).to receive_messages(body: nil, width: 100, height: 100)
+      allow(subject).to receive(:svg).and_return(svg)
     end
 
     describe '#save' do
-      let(:svg) { double save: true }
-
       it 'delegates to SVG' do
-        allow(subject).to receive(:svg).and_return(svg)
         expect(svg).to receive(:save).with('filename')
         subject.save 'filename'
       end
     end
 
     describe '#render' do
-      let(:svg) { double render: true }
-
       it 'delegates to SVG' do
-        allow(subject).to receive(:svg).and_return(svg)
         expect(svg).to receive(:render).with(template: :minimal)
         subject.render template: :minimal
       end
     end
 
     describe '#content' do
-      let(:svg) { double content: true }
-
       it 'delegates to SVG' do
-        allow(subject).to receive(:svg).and_return(svg)
         expect(svg).to receive(:content)
         subject.content
+      end
+    end
+
+    describe '#element' do
+      it 'delegates to SVG' do
+        expect(svg).to receive(:element).with(:rect)
+        subject.element :rect
+      end
+    end
+
+    describe '#to_s' do
+      it 'delegates to SVG' do
+        expect(svg).to receive(:to_s)
+        subject.to_s
       end
     end
 

--- a/spec/victor/component_spec.rb
+++ b/spec/victor/component_spec.rb
@@ -41,44 +41,44 @@ describe Victor::Component do
     end
 
     describe '#save' do
+      let(:svg) { double save: true }
+
       it 'delegates to SVG' do
-        expect(subject.svg).to receive(:save).with('filename')
+        allow(subject).to receive(:svg).and_return(svg)
+        expect(svg).to receive(:save).with('filename')
         subject.save 'filename'
       end
     end
 
     describe '#render' do
+      let(:svg) { double render: true }
+
       it 'delegates to SVG' do
-        expect(subject.svg).to receive(:render).with(template: :minimal)
+        allow(subject).to receive(:svg).and_return(svg)
+        expect(svg).to receive(:render).with(template: :minimal)
         subject.render template: :minimal
       end
     end
 
-    describe '#vector' do
-      it 'returns an SVG object' do
-        expect(subject.vector).to be_a Victor::SVG
-      end
-    end
+    describe '#content' do
+      let(:svg) { double content: true }
 
-    describe '#add' do
-      it 'is an alias to #vector' do
-        expect(subject.add).to equal subject.vector
-      end
-    end
-
-    describe '#css' do
-      it 'returns a duplicate of #style' do
-        expect(subject.css).to eq subject.style
-        expect(subject.css).not_to equal subject.style
+      it 'delegates to SVG' do
+        allow(subject).to receive(:svg).and_return(svg)
+        expect(svg).to receive(:content)
+        subject.content
       end
     end
 
     describe '#append' do
-      let(:component) { double(:Component, svg: 'mocked_svg', css: { color: 'red' }) }
+      let(:component) { double svg: 'mocked_svg', css: { color: 'red' } }
+      let(:vector) { double append: true }
+      let(:css) { double merge!: true }
 
       it 'appends another component and merges its css' do
-        expect(subject.vector).to receive(:append).with('mocked_svg')
-        expect(subject.css).to receive(:merge!).with({ color: 'red' })
+        allow(subject).to receive_messages(vector: vector, css: css)
+        expect(vector).to receive(:append).with('mocked_svg')
+        expect(css).to receive(:merge!).with({ color: 'red' })
 
         subject.append component
       end

--- a/spec/victor/component_spec.rb
+++ b/spec/victor/component_spec.rb
@@ -1,0 +1,95 @@
+describe Victor::Component do
+  describe '#body' do
+    it 'raises a NotImplementedError' do
+      expect { subject.body }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#height' do
+    it 'raises a NotImplementedError' do
+      expect { subject.height }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#width' do
+    it 'raises a NotImplementedError' do
+      expect { subject.width }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#style' do
+    it 'returns an empty hash' do
+      expect(subject.style).to eq({})
+    end
+  end
+
+  describe '#x' do
+    it 'returns 0' do
+      expect(subject.x).to eq 0
+    end
+  end
+
+  describe '#y' do
+    it 'returns 0' do
+      expect(subject.y).to eq 0
+    end
+  end
+
+  context 'when all required methods are implemented' do
+    before do
+      allow(subject).to receive(:body)
+      allow(subject).to receive(:width).and_return 100
+      allow(subject).to receive(:height).and_return 100
+    end
+
+    describe '#save' do
+      it 'delegates to SVG' do
+        expect(subject.svg).to receive(:save).with('filename')
+        subject.save 'filename'
+      end
+    end
+
+    describe '#render' do
+      it 'delegates to SVG' do
+        expect(subject.svg).to receive(:render).with(template: :minimal)
+        subject.render template: :minimal
+      end
+    end
+
+    describe '#vector' do
+      it 'returns an SVG object' do
+        expect(subject.vector).to be_a Victor::SVG
+      end
+    end
+
+    describe '#add' do
+      it 'is an alias to #vector' do
+        expect(subject.add).to equal subject.vector
+      end
+    end
+
+    describe '#css' do
+      it 'returns a duplicate of #style' do
+        expect(subject.css).to eq subject.style
+        expect(subject.css).not_to equal subject.style
+      end
+    end
+
+    describe '#append' do
+      let(:component) { double(:Component, svg: 'mocked_svg', css: { color: 'red' }) }
+
+      it 'appends another component and merges its css' do
+        expect(subject.vector).to receive(:append).with('mocked_svg')
+        expect(subject.css).to receive(:merge!).with({ color: 'red' })
+
+        subject.append component
+      end
+    end
+
+    describe '#embed' do
+      it 'is an alias to #append' do
+        expect(subject.method(:embed)).to eq subject.method(:append)
+      end
+    end
+  end
+end

--- a/spec/victor/component_spec.rb
+++ b/spec/victor/component_spec.rb
@@ -37,9 +37,7 @@ describe Victor::Component do
 
   context 'when all required methods are implemented' do
     before do
-      allow(subject).to receive(:body)
-      allow(subject).to receive(:width).and_return 100
-      allow(subject).to receive(:height).and_return 100
+      allow(subject).to receive_messages(body: nil, width: 100, height: 100)
     end
 
     describe '#save' do

--- a/spec/victor/component_subclass_spec.rb
+++ b/spec/victor/component_subclass_spec.rb
@@ -1,0 +1,11 @@
+require_relative '../fixtures/components/component_set1'
+
+describe 'Component subclassing' do
+  subject { ComponentSet1::Main.new }
+
+  describe '#render' do
+    it 'returns the expected SVG' do
+      expect(subject.render).to match_approval 'component/set1/render'
+    end
+  end
+end

--- a/spec/victor/marshaling_spec.rb
+++ b/spec/victor/marshaling_spec.rb
@@ -1,0 +1,13 @@
+describe Victor::Marshaling do
+  subject do
+    Class.new do
+      include Victor::Marshaling
+    end.new
+  end
+
+  describe '#marshaling' do
+    it 'raises a NotImplementedError' do
+      expect { subject.marshaling }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -1,5 +1,5 @@
 describe Victor::SVG do
-  describe '#new' do
+  describe '#initialize' do
     it 'sets default attributes' do
       expect(subject.svg_attributes[:height]).to eq '100%'
       expect(subject.svg_attributes[:width]).to eq '100%'

--- a/spec/victor/svg_spec.rb
+++ b/spec/victor/svg_spec.rb
@@ -58,12 +58,14 @@ describe Victor::SVG do
     end
 
     describe '#append' do
-      it 'pushes stringable objects as content' do
-        subject.append fire
-        subject.append earth
-        subject.append water
+      it 'is an alias to #<<' do
+        expect(subject.method(:append)).to eq subject.method(:<<)
+      end
+    end
 
-        expect(subject.to_s).to eq "<circle color=\"red\"/>\n<triangle color=\"green\"/>\n<rect color=\"blue\"/>"
+    describe '#embed' do
+      it 'is an alias to #<<' do
+        expect(subject.method(:embed)).to eq subject.method(:<<)
       end
     end
   end


### PR DESCRIPTION
This PR adds `SVG::Component` class, for component-driven SVG design.

In addition:
- All code is now autoloaded instead of required.
- Marshalling was updated and applied to `Component` as well.
- The `xmlns:xlink="http://www.w3.org/1999/xlink"` attribute was removed from SVG templates.
- Added `SVG#embed` as an alias to `SVG#append`.